### PR TITLE
feat(#18): RPC hardening — retry, fallback endpoints, user-safe errors

### DIFF
--- a/apps/mobile/lib/starknet/networks.ts
+++ b/apps/mobile/lib/starknet/networks.ts
@@ -4,22 +4,38 @@ export type StarknetNetworkConfig = {
   id: StarknetNetworkId;
   name: string;
   rpcUrl: string;
+  /** Additional RPC endpoints to try when the primary fails. */
+  rpcFallbackUrls: string[];
   chainIdHex: string;
 };
 
-// Public RPC endpoints (no API key) via publicnode.
+// Public RPC endpoints (no API key required).
 export const STARKNET_NETWORKS: Record<StarknetNetworkId, StarknetNetworkConfig> =
   {
     sepolia: {
       id: "sepolia",
       name: "Sepolia",
       rpcUrl: "https://starknet-sepolia-rpc.publicnode.com",
+      rpcFallbackUrls: [
+        "https://free-rpc.nethermind.io/sepolia-juno/",
+      ],
       chainIdHex: "0x534e5f5345504f4c4941", // SN_SEPOLIA
     },
     mainnet: {
       id: "mainnet",
       name: "Mainnet",
       rpcUrl: "https://starknet-rpc.publicnode.com",
+      rpcFallbackUrls: [
+        "https://free-rpc.nethermind.io/mainnet-juno/",
+      ],
       chainIdHex: "0x534e5f4d41494e", // SN_MAIN
     },
   };
+
+/**
+ * Returns all RPC URLs for a network: primary first, then fallbacks.
+ */
+export function getAllRpcUrls(networkId: StarknetNetworkId): string[] {
+  const net = STARKNET_NETWORKS[networkId];
+  return [net.rpcUrl, ...net.rpcFallbackUrls];
+}

--- a/apps/mobile/lib/starknet/rpc.ts
+++ b/apps/mobile/lib/starknet/rpc.ts
@@ -1,3 +1,7 @@
+// ---------------------------------------------------------------------------
+// Starknet JSON-RPC client with retry, fallback endpoints, and user-safe errors
+// ---------------------------------------------------------------------------
+
 type JsonRpcSuccess<T> = {
   jsonrpc: "2.0";
   id: number;
@@ -12,6 +16,10 @@ type JsonRpcError = {
 
 type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcError;
 
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
 export class StarknetRpcError extends Error {
   readonly code?: number;
   readonly data?: unknown;
@@ -23,6 +31,157 @@ export class StarknetRpcError extends Error {
     this.data = opts?.data;
   }
 }
+
+/** Error kinds surfaced to the UI. */
+export type RpcErrorKind =
+  | "timeout"
+  | "network_offline"
+  | "rate_limited"
+  | "insufficient_funds"
+  | "nonce_mismatch"
+  | "chain_id_mismatch"
+  | "policy_revert"
+  | "contract_not_found"
+  | "unknown";
+
+/**
+ * Classify a raw error into a kind + user-safe message.
+ * Callers can show `userMessage` directly in the UI without leaking internals.
+ */
+export function classifyRpcError(err: unknown): {
+  kind: RpcErrorKind;
+  userMessage: string;
+} {
+  const msg =
+    err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+  const code = err instanceof StarknetRpcError ? err.code : undefined;
+
+  if (isAbortError(err) || msg.includes("timeout") || msg.includes("aborted")) {
+    return {
+      kind: "timeout",
+      userMessage: "Request timed out. Check your connection and try again.",
+    };
+  }
+  if (msg.includes("network") || msg.includes("failed to fetch") || msg.includes("enetunreach")) {
+    return {
+      kind: "network_offline",
+      userMessage: "Unable to reach the network. Check your internet connection.",
+    };
+  }
+  if (code === 429 || msg.includes("rate limit") || msg.includes("too many requests")) {
+    return {
+      kind: "rate_limited",
+      userMessage: "Too many requests. Please wait a moment and try again.",
+    };
+  }
+  if (msg.includes("insufficient") && msg.includes("fund")) {
+    return {
+      kind: "insufficient_funds",
+      userMessage: "Insufficient funds to complete this transaction.",
+    };
+  }
+  if (msg.includes("nonce")) {
+    return {
+      kind: "nonce_mismatch",
+      userMessage:
+        "Transaction nonce mismatch. A previous transaction may still be pending.",
+    };
+  }
+  if (msg.includes("chain") && msg.includes("id")) {
+    return {
+      kind: "chain_id_mismatch",
+      userMessage: "Chain ID mismatch. Make sure you are on the correct network.",
+    };
+  }
+  if (msg.includes("session") || msg.includes("policy") || msg.includes("spending limit") || msg.includes("not allowed")) {
+    return {
+      kind: "policy_revert",
+      userMessage:
+        "Transaction denied by your security policy. Adjust your policy or use owner approval.",
+    };
+  }
+  if (msg.includes("contract not found") || msg.includes("requested contract address") || msg.includes("invalid contract address")) {
+    return {
+      kind: "contract_not_found",
+      userMessage: "Contract not found at the given address.",
+    };
+  }
+
+  return {
+    kind: "unknown",
+    userMessage: "Something went wrong. Please try again.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retry policy (centralized)
+// ---------------------------------------------------------------------------
+
+/** Default retry config. Callers can override per-call. */
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 5_000;
+
+export type RetryOpts = {
+  /** Maximum number of retry attempts (0 = no retries). Default: 2. */
+  maxRetries?: number;
+  /** Initial backoff delay in ms. Default: 500. */
+  baseDelayMs?: number;
+  /** Maximum backoff delay in ms. Default: 5000. */
+  maxDelayMs?: number;
+};
+
+/** Returns true for errors that are safe to retry. */
+function isRetryable(err: unknown): boolean {
+  if (isAbortError(err)) return true; // timeout → retry
+
+  if (err instanceof StarknetRpcError) {
+    // HTTP 429, 500, 502, 503, 504 are retryable
+    const httpStatus = extractHttpStatus(err.message);
+    if (httpStatus !== null && [429, 500, 502, 503, 504].includes(httpStatus)) {
+      return true;
+    }
+    // JSON-RPC internal error (-32000 to -32099) can be transient
+    if (err.code !== undefined && err.code <= -32000 && err.code >= -32099) {
+      return true;
+    }
+  }
+
+  const msg =
+    err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+  if (msg.includes("failed to fetch") || msg.includes("network") || msg.includes("enetunreach")) {
+    return true;
+  }
+
+  return false;
+}
+
+function extractHttpStatus(message: string): number | null {
+  const m = message.match(/^HTTP (\d{3})/);
+  return m ? Number(m[1]) : null;
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    (err instanceof DOMException && err.name === "AbortError") ||
+    (err instanceof Error && err.name === "AbortError")
+  );
+}
+
+/** Sleep with exponential backoff + jitter. */
+function backoffDelay(
+  attempt: number,
+  baseMs: number,
+  maxMs: number
+): Promise<void> {
+  const exp = Math.min(baseMs * 2 ** attempt, maxMs);
+  const jitter = exp * 0.5 * Math.random();
+  return new Promise((resolve) => setTimeout(resolve, exp + jitter));
+}
+
+// ---------------------------------------------------------------------------
+// Core RPC call
+// ---------------------------------------------------------------------------
 
 async function fetchJsonWithTimeout(
   url: string,
@@ -38,14 +197,13 @@ async function fetchJsonWithTimeout(
   }
 }
 
-export async function starknetRpc<T>(
+/** Single-shot RPC call against one URL (no retries). */
+async function rpcOnce<T>(
   rpcUrl: string,
   method: string,
-  params: unknown[] = [],
-  opts?: { timeoutMs?: number }
+  params: unknown[],
+  timeoutMs: number
 ): Promise<T> {
-  const timeoutMs = opts?.timeoutMs ?? 15_000;
-
   const res = await fetchJsonWithTimeout(
     rpcUrl,
     {
@@ -71,6 +229,65 @@ export async function starknetRpc<T>(
 
   return json.result;
 }
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type RpcCallOpts = {
+  timeoutMs?: number;
+  /** Additional URLs to try if the primary fails with a retryable error. */
+  fallbackUrls?: string[];
+} & RetryOpts;
+
+/**
+ * Make a Starknet JSON-RPC call with automatic retry and optional fallback.
+ *
+ * Retry policy:
+ *  - Only retryable errors (timeouts, 5xx, network failures) are retried.
+ *  - Exponential backoff with jitter between attempts.
+ *  - After exhausting retries on the primary URL, each fallback URL is tried
+ *    with the same retry budget.
+ *  - Total attempts = (1 + maxRetries) * (1 + fallbackUrls.length).
+ */
+export async function starknetRpc<T>(
+  rpcUrl: string,
+  method: string,
+  params: unknown[] = [],
+  opts?: RpcCallOpts
+): Promise<T> {
+  const timeoutMs = opts?.timeoutMs ?? 15_000;
+  const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = opts?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = opts?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const urls = [rpcUrl, ...(opts?.fallbackUrls ?? [])];
+
+  let lastError: unknown;
+
+  for (const url of urls) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await rpcOnce<T>(url, method, params, timeoutMs);
+      } catch (err) {
+        lastError = err;
+        const retriesLeft = attempt < maxRetries;
+        if (retriesLeft && isRetryable(err)) {
+          await backoffDelay(attempt, baseDelayMs, maxDelayMs);
+          continue;
+        }
+        // Non-retryable or retries exhausted for this URL → try next URL
+        break;
+      }
+    }
+  }
+
+  // All URLs and retries exhausted.
+  throw lastError;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrappers (unchanged signatures, now inherit retry behaviour)
+// ---------------------------------------------------------------------------
 
 export async function getChainId(rpcUrl: string): Promise<string> {
   return starknetRpc<string>(rpcUrl, "starknet_chainId", []);


### PR DESCRIPTION
## Summary
Closes #18

## What changed

**`apps/mobile/lib/starknet/rpc.ts`** — Centralized retry policy:
- **Exponential backoff with jitter**: retries transient errors (timeouts, HTTP 429/5xx, network failures, JSON-RPC internal errors) up to 2 times by default with increasing delays (500ms base, 5s cap).
- **Fallback URL support**: after exhausting retries on the primary endpoint, each fallback URL gets the same retry budget. Total attempts = `(1 + maxRetries) × (1 + fallbackUrls.length)`.
- **No infinite retry loops**: bounded by `maxRetries` per URL, finite URL list.
- **`classifyRpcError()`**: maps raw errors to `{ kind, userMessage }` for actionable UI display without leaking internals. Covers: timeout, network offline, rate limited, insufficient funds, nonce mismatch, chain ID mismatch, policy revert, contract not found.
- **Backward-compatible**: existing callers automatically get retry behavior; the `starknetRpc()` signature is extended (not changed).

**`apps/mobile/lib/starknet/networks.ts`** — Fallback endpoints:
- Added `rpcFallbackUrls` field to `StarknetNetworkConfig`.
- Added Nethermind free Juno endpoints as fallbacks for both Sepolia and Mainnet.
- Added `getAllRpcUrls(networkId)` helper to get [primary, ...fallbacks].

## How to verify

\`\`\`bash
# Typecheck + lint
./scripts/app/check

# The retry/fallback logic is exercised automatically by starknetRpc().
# To test manually: temporarily point rpcUrl to a bad endpoint and
# verify the fallback kicks in within ~2s.
\`\`\`

## Security checklist
- [x] No secrets, keys, or mnemonics in code or logs
- [x] No unsafe blocks
- [x] No bypassing of session key / policy validation
- [x] Spending limits unaffected
- [x] User-safe error messages don't leak internal details

## Agent
\`agent-0708d554\`