### PR TITLE
docs(#1): Align public docs with current app modes (demo vs live)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@ Starkclaw: a premium mobile personal agent that can execute Starknet transaction
 </identity>
 
 <status>
-MVP demo flow is implemented end-to-end in the mobile app (wallet create/fund/deploy, session key policies, constrained ERC20 transfers, activity log). Source of truth: `STATUS.md`.
+App runs in demo mode (UI-only, fully mocked). Live Starknet execution libs exist in `apps/mobile/lib/` but aren't wired to UI yet (issue #2 tracks backend abstraction). Source of truth: `STATUS.md`.
 </status>
 
 <environment>
@@ -24,24 +24,20 @@ Assume the user does not see raw command output; summarize important results.
 </stack>
 
 <structure>
-<current>
-- `apps/mobile/`: Expo app (Starkclaw MVP: wallet, policies, agent, activity)
+- `apps/mobile/`: Expo app (currently demo mode UI; live libs exist in `lib/` subdirs but not wired)
+  - `lib/demo/`: Mocked state for demo mode (currently active)
+  - `lib/starknet/`: RPC client, account, session signer (exists, not wired)
+  - `lib/wallet/`, `lib/policy/`, `lib/agent/`, `lib/activity/`: Live execution libs (exists, not wired)
+  - `app/(tabs)/`: Tab screens (index, trade, agent, policies, inbox)
+  - `app/(onboarding)/`: Onboarding flow
 - `contracts/agent-account/`: Cairo account contract + tests (session keys + policy enforcement)
-- `scripts/`: canonical commands used by CI
+- `scripts/`: Canonical commands used by CI (`check`, `app/dev`, `contracts/test`, etc.)
 - `.github/workflows/ci.yml`: CI entrypoint (runs `./scripts/check`)
-- `spec.md`: expanded MVP spec
-- `IMPLEMENTATION_PLAN.md`: milestones + acceptance criteria
-- `STATUS.md`: current milestone + verification steps
-- `spec.draft.md`: preserved original notes
-- `.claude/skills/`: reusable skill packs (treat as vendored)
-- `.codex` -> `.claude`: symlink (single source of truth is `.claude`)
-</current>
-<target_m00_plus>
-- `apps/mobile/`: Expo app
-- `contracts/`: Cairo contracts + tests + deploy scripts
-- `packages/`: shared TS packages (agent runtime, starknet utils)
-- `scripts/`: deterministic check/dev commands used by CI
-</target_m00_plus>
+- `spec.md`: Expanded MVP spec
+- `IMPLEMENTATION_PLAN.md`: Milestones + acceptance criteria
+- `STATUS.md`: Current milestone + verification steps
+- `.claude/skills/`: Reusable skill packs (treat as vendored)
+- `.codex` -> `.claude`: Symlink (single source of truth is `.claude`)
 </structure>
 
 <conventions>


### PR DESCRIPTION
## Summary
Closes #1

Aligns root-level docs (README, STATUS, CLAUDE.md) with current reality:
- App currently runs in **demo mode** (UI-only, mocked state)
- Live Starknet execution libs exist in `apps/mobile/lib/` but aren't wired to UI yet (#2)

This fixes contributor confusion and false expectations about what works today.

## What changed

**README.md:**
- Replaced "What is the MVP target" with "What Works Today" (demo mode) vs "What's Being Built" (live libs)
- Updated "Running The Sepolia Demo" → "Running Live Mode (When Available)" with note about #2
- Clarified "What This Is Not (Yet)" to mention live mode isn't wired

**STATUS.md:**
- Updated "Completed" section to clarify M02-M06 libs exist but aren't wired to UI
- Added note about demo mode being active
- Restructured "How To Verify" into "Demo Mode (Current)" vs "Live Mode (When Wired)"
- Updated "Next Up" to prioritize #2 (backend abstraction)

**CLAUDE.md:**
- Updated `<status>` to reflect demo mode + live libs exist but not wired
- Expanded `<structure>` to clarify `apps/mobile/lib/` organization (demo vs live libs)

## How to verify
- `./scripts/app/check` passes ✅
- README no longer claims E2E Sepolia flow works today
- STATUS.md matches apps/mobile/README.md (both say demo mode)
- No stale file references

## Agent
`agent-5a1972f1`