### PR TITLE
chore(#22): add issue templates + PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: Report a bug in Starkclaw
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please fill out the sections below so we can reproduce and fix the issue.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Open the app
+        2. Navigate to ...
+        3. Tap ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Mobile app
+        - Cairo contracts
+        - Agent runtime
+        - Scripts / CI
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, device, Expo SDK version, Scarb version, etc.
+      placeholder: "iOS 18, iPhone 15 Pro, Expo SDK 54"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste relevant logs or attach screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the feature you'd like. Include acceptance criteria so an agent or contributor can implement it independently.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work? Be as concrete as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this is done? List verifiable checks.
+      placeholder: |
+        - [ ] Feature X works when ...
+        - [ ] `./scripts/check` passes
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Mobile app
+        - Cairo contracts
+        - Agent runtime
+        - Scripts / CI
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why this one is better.

--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,20 @@
+name: Security Report
+description: Report a security vulnerability (redirects to SECURITY.md)
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Do not open public issues for security vulnerabilities.**
+
+        Please report security issues privately using one of the methods described in [SECURITY.md](https://github.com/keep-starknet-strange/starkclaw/blob/main/SECURITY.md):
+
+        - **Preferred:** [GitHub Security Advisories](https://github.com/keep-starknet-strange/starkclaw/security/advisories/new)
+        - **Alternative:** Email security@starkware.co (mention "Starkclaw" in subject)
+
+        If you're unsure whether something is a security issue, err on the side of caution and report privately.
+  - type: textarea
+    id: confirm
+    attributes:
+      label: Confirmation
+      description: "If this is NOT a security vulnerability and you still want to file it here, describe why below. Otherwise, please close this and use the private reporting channels above."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## What changed
+
+<!-- Describe the changes. Link the issue this addresses. -->
+
+Closes #
+
+## How to verify
+
+```bash
+./scripts/check
+```
+
+<!-- Add any manual verification steps. -->
+
+## Risk notes
+
+<!-- Flag anything risky: breaking changes, new dependencies, security-sensitive code. "None" is fine. -->
+
+## Screenshots / videos
+
+<!-- For UI changes, attach screenshots or a short video. Delete this section if N/A. -->
+
+## Security checklist
+
+- [ ] No secrets, keys, or mnemonics in code or logs
+- [ ] No `unsafe` blocks without justification
+- [ ] ERC-20 interactions check return values (if applicable)
+- [ ] Session key validation cannot be bypassed (if applicable)
+- [ ] Spending limits cannot overflow or underflow (if applicable)


### PR DESCRIPTION
## What changed
Closes #22

- Bug report template (`.github/ISSUE_TEMPLATE/bug_report.yml`) — structured fields for reproduction steps, component, environment.
- Feature request template (`.github/ISSUE_TEMPLATE/feature_request.yml`) — problem/solution/acceptance criteria fields.
- Security report template (`.github/ISSUE_TEMPLATE/security_report.yml`) — redirects to SECURITY.md private channels.
- PR template (`.github/pull_request_template.md`) — what changed, how to verify, risk notes, security checklist.

## How to verify
Templates render correctly on GitHub's issue/PR creation pages.

## Risk notes
None — new files only.

## Agent
`agent-0708d554`