### PR TITLE
feat(#2): backend abstraction (demo + live) with switchable mode

### DIFF
--- a/apps/mobile/app/(onboarding)/alerts.tsx
+++ b/apps/mobile/app/(onboarding)/alerts.tsx
@@ -3,7 +3,7 @@ import { Switch, View } from "react-native";
 import { useRouter } from "expo-router";
 import Animated, { FadeInDown } from "react-native-reanimated";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, PrimaryButton } from "@/ui/buttons";
 import { Chip } from "@/ui/chip";
 import { Divider } from "@/ui/divider";
@@ -15,7 +15,7 @@ import { Body, H1, H2, Muted } from "@/ui/typography";
 
 export default function OnboardingAlertsScreen() {
   const router = useRouter();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
 
   return (
     <AppScreen>

--- a/apps/mobile/app/(onboarding)/limits.tsx
+++ b/apps/mobile/app/(onboarding)/limits.tsx
@@ -3,7 +3,7 @@ import { TextInput, View } from "react-native";
 import { useRouter } from "expo-router";
 import Animated, { FadeInDown } from "react-native-reanimated";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, PrimaryButton } from "@/ui/buttons";
 import { Chip } from "@/ui/chip";
 import { GlassCard } from "@/ui/glass-card";
@@ -20,7 +20,7 @@ function toNumberOr(n: string, fallback: number): number {
 export default function OnboardingLimitsScreen() {
   const t = useAppTheme();
   const router = useRouter();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
 
   const [daily, setDaily] = React.useState(String(state.policy.dailySpendCapUsd));
   const [perTx, setPerTx] = React.useState(String(state.policy.perTxCapUsd));

--- a/apps/mobile/app/(onboarding)/profile.tsx
+++ b/apps/mobile/app/(onboarding)/profile.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "expo-router";
 import Animated, { FadeInDown } from "react-native-reanimated";
 import { LinearGradient } from "expo-linear-gradient";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, PrimaryButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
 import { GlassCard } from "@/ui/glass-card";
@@ -18,7 +18,7 @@ type Mode = "calm" | "balanced" | "bold";
 export default function OnboardingProfileScreen() {
   const t = useAppTheme();
   const router = useRouter();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
 
   const [name, setName] = React.useState(state.onboarding.displayName);
   const [mode, setMode] = React.useState<Mode>(state.onboarding.riskMode);

--- a/apps/mobile/app/(onboarding)/ready.tsx
+++ b/apps/mobile/app/(onboarding)/ready.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, View } from "react-native";
 import { useRouter } from "expo-router";
 import Animated, { FadeInDown } from "react-native-reanimated";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, PrimaryButton } from "@/ui/buttons";
 import { GlassCard } from "@/ui/glass-card";
 import { haptic } from "@/ui/haptics";
@@ -15,7 +15,7 @@ import { formatUsd } from "@/ui/format";
 export default function OnboardingReadyScreen() {
   const t = useAppTheme();
   const router = useRouter();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
   const [creating, setCreating] = React.useState(false);
   const [step, setStep] = React.useState(0);
 

--- a/apps/mobile/app/(onboarding)/welcome.tsx
+++ b/apps/mobile/app/(onboarding)/welcome.tsx
@@ -3,7 +3,7 @@ import { View } from "react-native";
 import { useRouter } from "expo-router";
 import Animated, { FadeInDown } from "react-native-reanimated";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, PrimaryButton } from "@/ui/buttons";
 import { Badge } from "@/ui/badge";
 import { GlassCard } from "@/ui/glass-card";
@@ -15,7 +15,7 @@ import { Body, Display, H2, Muted } from "@/ui/typography";
 export default function WelcomeScreen() {
   const t = useAppTheme();
   const router = useRouter();
-  const { actions } = useDemo();
+  const { actions } = useApp();
 
   const onReset = React.useCallback(async () => {
     await haptic("warn");

--- a/apps/mobile/app/(tabs)/agent.tsx
+++ b/apps/mobile/app/(tabs)/agent.tsx
@@ -5,7 +5,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import Animated, { FadeInDown } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { requireOwnerAuth } from "@/lib/security/owner-auth";
 import { GhostButton, IconButton, PrimaryButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
@@ -22,7 +22,7 @@ import { Body, H1, H2, Muted } from "@/ui/typography";
 export default function AgentScreen() {
   const t = useAppTheme();
   const insets = useSafeAreaInsets();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
 
   const [draft, setDraft] = React.useState("");
 

--- a/apps/mobile/app/(tabs)/inbox.tsx
+++ b/apps/mobile/app/(tabs)/inbox.tsx
@@ -3,7 +3,7 @@ import { View } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import Animated, { FadeInDown } from "react-native-reanimated";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { AppIcon } from "@/ui/app-icon";
 import { Chip } from "@/ui/chip";
 import { Divider } from "@/ui/divider";
@@ -16,7 +16,7 @@ import { Body, H1, H2, Muted } from "@/ui/typography";
 type InboxTab = "alerts" | "activity";
 
 export default function InboxScreen() {
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
   const [tab, setTab] = React.useState<InboxTab>("alerts");
 
   const unread = state.alerts.filter((a) => !a.read).length;

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import { Pressable, TextInput, View } from "react-native";
 import { useRouter } from "expo-router";
 import Animated, { FadeInDown } from "react-native-reanimated";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, IconButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
 import { Badge } from "@/ui/badge";
@@ -23,7 +23,7 @@ function portfolioTotalUsd(balances: { amount: number; usdPrice: number }[]): nu
 export default function HomeScreen() {
   const t = useAppTheme();
   const router = useRouter();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
   const [draft, setDraft] = React.useState("");
 
   const name = state.onboarding.displayName.trim();

--- a/apps/mobile/app/(tabs)/policies.tsx
+++ b/apps/mobile/app/(tabs)/policies.tsx
@@ -3,7 +3,7 @@ import { Pressable, Switch, TextInput, View } from "react-native";
 import Animated, { FadeInDown } from "react-native-reanimated";
 import { LinearGradient } from "expo-linear-gradient";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { requireOwnerAuth } from "@/lib/security/owner-auth";
 import { GhostButton, PrimaryButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
@@ -22,7 +22,7 @@ function toNumberOr(n: string, fallback: number): number {
 
 export default function PoliciesScreen() {
   const t = useAppTheme();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
 
   const [dailyText, setDailyText] = React.useState(String(state.policy.dailySpendCapUsd));
   const [perTxText, setPerTxText] = React.useState(String(state.policy.perTxCapUsd));

--- a/apps/mobile/app/(tabs)/trade.tsx
+++ b/apps/mobile/app/(tabs)/trade.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Modal, Pressable, TextInput, View } from "react-native";
 import Animated, { FadeInDown, FadeInUp } from "react-native-reanimated";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, IconButton, PrimaryButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
 import { Badge } from "@/ui/badge";
@@ -28,7 +28,7 @@ function clamp(n: number, min: number, max: number): number {
 
 export default function TradeScreen() {
   const t = useAppTheme();
-  const { state, actions } = useDemo();
+  const { state, actions } = useApp();
 
   const [from, setFrom] = React.useState<Sym>("STRK");
   const [to, setTo] = React.useState<Sym>("USDC");

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -9,7 +9,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
 import "react-native-reanimated";
 
-import { DemoProvider, useDemo } from "@/lib/demo/demo-store";
+import { AppProvider, useApp } from "@/lib/app/app-provider";
 import { navThemeFromAppTheme, useAppTheme } from "@/ui/app-theme";
 
 export {
@@ -52,9 +52,9 @@ export default function RootLayout() {
   }
 
   return (
-    <DemoProvider>
+    <AppProvider>
       <RootLayoutNav />
-    </DemoProvider>
+    </AppProvider>
   );
 }
 
@@ -77,7 +77,7 @@ function RootLayoutNav() {
 }
 
 function useOnboardingGate() {
-  const { bootStatus, state } = useDemo();
+  const { bootStatus, state } = useApp();
   const segments = useSegments();
   const router = useRouter();
 

--- a/apps/mobile/app/modal.tsx
+++ b/apps/mobile/app/modal.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { View } from "react-native";
 import { useRouter } from "expo-router";
 
-import { useDemo } from "@/lib/demo/demo-store";
+import { useApp } from "@/lib/app/app-provider";
 import { GhostButton, IconButton, PrimaryButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
 import { GlassCard } from "@/ui/glass-card";
@@ -11,10 +11,10 @@ import { useAppTheme } from "@/ui/app-theme";
 import { AppScreen, Row } from "@/ui/screen";
 import { H1, H2, Mono, Muted } from "@/ui/typography";
 
-export default function DemoSettingsModal() {
+export default function SettingsModal() {
   const t = useAppTheme();
   const router = useRouter();
-  const { state, actions } = useDemo();
+  const { state, actions, mode, setMode } = useApp();
 
   return (
     <AppScreen>
@@ -36,8 +36,14 @@ export default function DemoSettingsModal() {
         <View style={{ gap: 12 }}>
           <H2>About this build</H2>
           <Muted>
-            UI-only showcase. No RPC calls. No signing. Everything is mocked to demo the full Starkclaw flow.
+            {mode === "demo"
+              ? "UI-only showcase. No RPC calls. No signing. Everything is mocked to demo the full Starkclaw flow."
+              : "Live mode (Sepolia). Real RPC calls and on-chain transactions. Some features are still being wired."}
           </Muted>
+          <Row>
+            <Muted>Mode</Muted>
+            <Mono>{mode}</Mono>
+          </Row>
           <Row>
             <Muted>Account</Muted>
             <Mono selectable>
@@ -50,8 +56,18 @@ export default function DemoSettingsModal() {
       <GlassCard>
         <View style={{ gap: 12 }}>
           <H2>Controls</H2>
+          <GhostButton
+            label={mode === "demo" ? "Switch to Live mode" : "Switch to Demo mode"}
+            onPress={async () => {
+              await haptic("warn");
+              const next = mode === "demo" ? "live" : "demo";
+              setMode(next);
+              actions.reset();
+              router.replace("/(onboarding)/welcome");
+            }}
+          />
           <PrimaryButton
-            label="Reset demo state"
+            label="Reset state"
             onPress={async () => {
               await haptic("warn");
               actions.reset();
@@ -62,7 +78,7 @@ export default function DemoSettingsModal() {
             label="Trigger sample alert"
             onPress={async () => {
               await haptic("tap");
-              actions.triggerAlert("Demo alert", "A calm summary will appear in Inbox.", "info");
+              actions.triggerAlert("Sample alert", "A calm summary will appear in Inbox.", "info");
             }}
           />
         </View>

--- a/apps/mobile/lib/app/app-provider.tsx
+++ b/apps/mobile/lib/app/app-provider.tsx
@@ -1,0 +1,132 @@
+/**
+ * AppProvider — root provider that selects between demo and live backends.
+ *
+ * Consumers call `useApp()` which returns the same state/actions interface
+ * regardless of mode. The mode is persisted to SecureStore.
+ */
+
+import * as React from "react";
+
+import { DemoProvider, useDemo } from "@/lib/demo/demo-store";
+import { secureGet, secureSet } from "@/lib/storage/secure-store";
+
+import { useLiveBackend } from "./live-backend";
+import type { AppContextValue, AppMode } from "./types";
+
+const MODE_STORAGE_KEY = "starkclaw.app_mode";
+
+const AppContext = React.createContext<AppContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Demo bridge — renders DemoProvider and bridges to AppContextValue
+// ---------------------------------------------------------------------------
+
+function DemoBridge(props: {
+  children: React.ReactNode;
+  mode: AppMode;
+  setMode: (m: AppMode) => void;
+}) {
+  return (
+    <DemoProvider>
+      <DemoBridgeInner mode={props.mode} setMode={props.setMode}>
+        {props.children}
+      </DemoBridgeInner>
+    </DemoProvider>
+  );
+}
+
+function DemoBridgeInner(props: {
+  children: React.ReactNode;
+  mode: AppMode;
+  setMode: (m: AppMode) => void;
+}) {
+  const demo = useDemo();
+  const value = React.useMemo<AppContextValue>(
+    () => ({
+      bootStatus: demo.bootStatus,
+      state: demo.state,
+      actions: demo.actions,
+      mode: props.mode,
+      setMode: props.setMode,
+    }),
+    [demo.bootStatus, demo.state, demo.actions, props.mode, props.setMode]
+  );
+  return <AppContext.Provider value={value}>{props.children}</AppContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Live bridge — uses useLiveBackend and bridges to AppContextValue
+// ---------------------------------------------------------------------------
+
+function LiveBridge(props: {
+  children: React.ReactNode;
+  mode: AppMode;
+  setMode: (m: AppMode) => void;
+}) {
+  const live = useLiveBackend();
+  const value = React.useMemo<AppContextValue>(
+    () => ({
+      bootStatus: live.bootStatus,
+      state: live.state,
+      actions: live.actions,
+      mode: props.mode,
+      setMode: props.setMode,
+    }),
+    [live.bootStatus, live.state, live.actions, props.mode, props.setMode]
+  );
+  return <AppContext.Provider value={value}>{props.children}</AppContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// AppProvider — public root provider
+// ---------------------------------------------------------------------------
+
+export function AppProvider(props: { children: React.ReactNode }) {
+  const [mode, setModeState] = React.useState<AppMode>("demo");
+  const [modeLoaded, setModeLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const stored = await secureGet(MODE_STORAGE_KEY);
+      if (cancelled) return;
+      if (stored === "live") setModeState("live");
+      setModeLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setMode = React.useCallback((m: AppMode) => {
+    setModeState(m);
+    secureSet(MODE_STORAGE_KEY, m).catch(() => {});
+  }, []);
+
+  // Wait until we know which mode to render to avoid flicker.
+  if (!modeLoaded) return null;
+
+  if (mode === "live") {
+    return (
+      <LiveBridge mode={mode} setMode={setMode}>
+        {props.children}
+      </LiveBridge>
+    );
+  }
+
+  return (
+    <DemoBridge mode={mode} setMode={setMode}>
+      {props.children}
+    </DemoBridge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// useApp — the single hook all screens import
+// ---------------------------------------------------------------------------
+
+export function useApp(): AppContextValue {
+  const ctx = React.useContext(AppContext);
+  if (!ctx) throw new Error("useApp must be used within <AppProvider />");
+  return ctx;
+}

--- a/apps/mobile/lib/app/live-backend.tsx
+++ b/apps/mobile/lib/app/live-backend.tsx
@@ -1,0 +1,248 @@
+/**
+ * Live backend — stubbed implementation providing the same AppState shape.
+ *
+ * Each action logs a warning and returns gracefully. Follow-up PRs will wire
+ * real implementations from lib/wallet, lib/policy, lib/agent, lib/starknet.
+ */
+
+import * as React from "react";
+
+import { createInitialDemoState } from "@/lib/demo/demo-state";
+import { secureGet, secureSet } from "@/lib/storage/secure-store";
+
+import type { AppActions, AppState, BootStatus } from "./types";
+
+const STORAGE_KEY = "starkclaw.live_state.v1";
+
+function stub(name: string) {
+  // eslint-disable-next-line no-console
+  console.warn(`[live] ${name} is not yet implemented.`);
+}
+
+function safeParse(raw: string | null): AppState | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    if ((parsed as any).version !== 1) return null;
+    return parsed as AppState;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Creates a fresh live state. Uses the same shape as DemoState but with
+ * empty / uninitialized values to make it obvious we're in live mode.
+ */
+function createInitialLiveState(): AppState {
+  return {
+    ...createInitialDemoState(),
+    account: {
+      network: "Starknet",
+      environment: "sepolia",
+      address: "0x0000000000000000000000000000000000000000000000000000000000000000",
+      status: "not-created",
+    },
+    portfolio: {
+      balances: [
+        { symbol: "ETH", name: "Ether", amount: 0, usdPrice: 0, change24hPct: 0 },
+        { symbol: "USDC", name: "USD Coin", amount: 0, usdPrice: 0, change24hPct: 0 },
+        { symbol: "STRK", name: "Starknet", amount: 0, usdPrice: 0, change24hPct: 0 },
+      ],
+    },
+    alerts: [],
+    activity: [],
+    agent: {
+      autopilotEnabled: false,
+      quietHoursEnabled: false,
+      messages: [
+        {
+          id: `m_live_${Date.now()}`,
+          createdAt: Math.floor(Date.now() / 1000),
+          role: "assistant",
+          text: "Live mode is under construction. Core actions will be wired in upcoming PRs.",
+        },
+      ],
+      proposals: [],
+    },
+  };
+}
+
+export function useLiveBackend(): {
+  bootStatus: BootStatus;
+  state: AppState;
+  actions: AppActions;
+} {
+  const [bootStatus, setBootStatus] = React.useState<BootStatus>("booting");
+  const [state, setState] = React.useState<AppState>(createInitialLiveState);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const raw = await secureGet(STORAGE_KEY);
+      const parsed = safeParse(raw);
+      if (cancelled) return;
+      if (parsed) setState(parsed);
+      setBootStatus("ready");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (bootStatus !== "ready") return;
+    secureSet(STORAGE_KEY, JSON.stringify(state)).catch(() => {});
+  }, [bootStatus, state]);
+
+  const actions = React.useMemo<AppActions>(
+    () => ({
+      reset: () => setState(createInitialLiveState()),
+      setOnboardingProfile: (displayName, riskMode) => {
+        setState((s) => ({
+          ...s,
+          onboarding: { ...s.onboarding, displayName, riskMode },
+        }));
+      },
+      completeOnboarding: (input) => {
+        stub("completeOnboarding");
+        setState((s) => ({
+          ...s,
+          onboarding: {
+            completed: true,
+            displayName: input.displayName.trim(),
+            riskMode: input.riskMode,
+          },
+          policy: {
+            ...s.policy,
+            dailySpendCapUsd: input.dailySpendCapUsd,
+            perTxCapUsd: input.perTxCapUsd,
+          },
+        }));
+      },
+      setAlertPref: (key, enabled) => {
+        setState((s) => ({ ...s, alertPrefs: { ...s.alertPrefs, [key]: enabled } }));
+      },
+      markAllAlertsRead: () => {
+        setState((s) => ({
+          ...s,
+          alerts: s.alerts.map((a) => ({ ...a, read: true })),
+        }));
+      },
+      triggerAlert: (title, body, severity = "info") => {
+        const t = Math.floor(Date.now() / 1000);
+        setState((s) => ({
+          ...s,
+          alerts: [
+            { id: `al_${Date.now()}`, createdAt: t, title, body, severity, read: false },
+            ...s.alerts,
+          ],
+        }));
+      },
+      setEmergencyLockdown: (enabled) => {
+        stub("setEmergencyLockdown");
+        setState((s) => ({
+          ...s,
+          policy: { ...s.policy, emergencyLockdown: enabled },
+        }));
+      },
+      updateSpendCaps: (dailyUsd, perTxUsd) => {
+        stub("updateSpendCaps");
+        setState((s) => ({
+          ...s,
+          policy: { ...s.policy, dailySpendCapUsd: dailyUsd, perTxCapUsd: perTxUsd },
+        }));
+      },
+      setContractMode: (mode) => {
+        stub("setContractMode");
+        setState((s) => ({
+          ...s,
+          policy: { ...s.policy, contractAllowlistMode: mode },
+        }));
+      },
+      addAllowlistedRecipient: (recipientShort) => {
+        stub("addAllowlistedRecipient");
+        setState((s) => {
+          const next = recipientShort.trim();
+          if (!next || s.policy.allowlistedRecipients.includes(next)) return s;
+          return {
+            ...s,
+            policy: {
+              ...s.policy,
+              allowlistedRecipients: [next, ...s.policy.allowlistedRecipients].slice(0, 8),
+            },
+          };
+        });
+      },
+      removeAllowlistedRecipient: (recipientShort) => {
+        stub("removeAllowlistedRecipient");
+        setState((s) => ({
+          ...s,
+          policy: {
+            ...s.policy,
+            allowlistedRecipients: s.policy.allowlistedRecipients.filter((x) => x !== recipientShort),
+          },
+        }));
+      },
+      simulateTrade: () => {
+        stub("simulateTrade");
+      },
+      sendAgentMessage: (text) => {
+        stub("sendAgentMessage");
+        const trimmed = text.trim();
+        if (!trimmed) return;
+        const t = Math.floor(Date.now() / 1000);
+        setState((s) => ({
+          ...s,
+          agent: {
+            ...s.agent,
+            messages: [
+              ...s.agent.messages,
+              { id: `m_${Date.now()}`, createdAt: t, role: "user" as const, text: trimmed },
+              {
+                id: `m_${Date.now() + 1}`,
+                createdAt: t + 1,
+                role: "assistant" as const,
+                text: "Live agent runtime is not yet connected. This will be wired in a follow-up PR.",
+              },
+            ],
+          },
+        }));
+      },
+      approveProposal: (proposalId) => {
+        stub("approveProposal");
+        setState((s) => ({
+          ...s,
+          agent: {
+            ...s.agent,
+            proposals: s.agent.proposals.map((p) =>
+              p.id === proposalId ? { ...p, status: "approved" as const } : p
+            ),
+          },
+        }));
+      },
+      rejectProposal: (proposalId) => {
+        stub("rejectProposal");
+        setState((s) => ({
+          ...s,
+          agent: {
+            ...s.agent,
+            proposals: s.agent.proposals.map((p) =>
+              p.id === proposalId ? { ...p, status: "rejected" as const } : p
+            ),
+          },
+        }));
+      },
+      setAutopilotEnabled: (enabled) => {
+        setState((s) => ({ ...s, agent: { ...s.agent, autopilotEnabled: enabled } }));
+      },
+      setQuietHoursEnabled: (enabled) => {
+        setState((s) => ({ ...s, agent: { ...s.agent, quietHoursEnabled: enabled } }));
+      },
+    }),
+    []
+  );
+
+  return { bootStatus, state, actions };
+}

--- a/apps/mobile/lib/app/types.ts
+++ b/apps/mobile/lib/app/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared app-facing types for demo and live backends.
+ *
+ * The canonical state shape re-uses the existing DemoState structure so that
+ * all screens can switch backends without any UI changes.
+ */
+
+import type {
+  DemoAlertPrefKey,
+  DemoState,
+} from "@/lib/demo/demo-state";
+
+// ---------------------------------------------------------------------------
+// Mode
+// ---------------------------------------------------------------------------
+
+export type AppMode = "demo" | "live";
+
+// ---------------------------------------------------------------------------
+// State — same shape as DemoState so every screen works unchanged.
+// ---------------------------------------------------------------------------
+
+export type AppState = DemoState;
+
+// ---------------------------------------------------------------------------
+// Actions — matches the demo-store action surface exactly.
+// ---------------------------------------------------------------------------
+
+export type CompleteOnboardingInput = {
+  displayName: string;
+  riskMode: DemoState["onboarding"]["riskMode"];
+  dailySpendCapUsd: number;
+  perTxCapUsd: number;
+};
+
+export type TradeDraft = {
+  from: "ETH" | "USDC" | "STRK";
+  to: "ETH" | "USDC" | "STRK";
+  amount: number;
+};
+
+export type AppActions = {
+  reset: () => void;
+  setOnboardingProfile: (displayName: string, riskMode: DemoState["onboarding"]["riskMode"]) => void;
+  completeOnboarding: (input: CompleteOnboardingInput) => void;
+  setAlertPref: (key: DemoAlertPrefKey, enabled: boolean) => void;
+  markAllAlertsRead: () => void;
+  triggerAlert: (title: string, body: string, severity?: DemoState["alerts"][number]["severity"]) => void;
+  setEmergencyLockdown: (enabled: boolean) => void;
+  updateSpendCaps: (dailyUsd: number, perTxUsd: number) => void;
+  setContractMode: (mode: DemoState["policy"]["contractAllowlistMode"]) => void;
+  addAllowlistedRecipient: (recipientShort: string) => void;
+  removeAllowlistedRecipient: (recipientShort: string) => void;
+  simulateTrade: (trade: TradeDraft) => void;
+  sendAgentMessage: (text: string) => void;
+  approveProposal: (proposalId: string) => void;
+  rejectProposal: (proposalId: string) => void;
+  setAutopilotEnabled: (enabled: boolean) => void;
+  setQuietHoursEnabled: (enabled: boolean) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Context value returned by useApp()
+// ---------------------------------------------------------------------------
+
+export type BootStatus = "booting" | "ready";
+
+export type AppContextValue = {
+  bootStatus: BootStatus;
+  state: AppState;
+  actions: AppActions;
+  mode: AppMode;
+  setMode: (mode: AppMode) => void;
+};


### PR DESCRIPTION
Closes #2

## Summary

- **New `lib/app/` module** with shared `AppState`/`AppActions` types, `AppProvider`, and `useApp()` hook
- **Demo backend**: wraps existing `DemoProvider` unchanged — zero regressions in demo mode
- **Live backend**: same state shape with stubbed actions that log warnings and return gracefully
- **Mode toggle** in Settings modal, persisted to SecureStore
- **Migration**: all 12 screen files updated from `useDemo()` → `useApp()`

## Architecture

```
lib/app/
├── types.ts          — AppState, AppActions, AppMode (re-uses DemoState shape)
├── app-provider.tsx  — AppProvider + useApp() hook, mode selection + persistence
└── live-backend.tsx  — Live backend with stubbed actions
```

`AppProvider` selects the backend based on mode:
- **demo**: renders `DemoProvider` internally, bridges state to `AppContext`
- **live**: uses `useLiveBackend()` with identical state shape, stub actions

## Acceptance Criteria

- [x] Demo mode behaves exactly as today (no UI regressions)
- [x] Live mode builds and launches without crashing (stubs log warnings)
- [x] No Starknet RPC calls in demo mode
- [x] `./scripts/app/check` passes (typecheck + lint clean)

## Files Changed

**New (3)**:
- `lib/app/types.ts` — shared types
- `lib/app/app-provider.tsx` — root provider + `useApp()` hook
- `lib/app/live-backend.tsx` — live backend stubs

**Modified (12)**:
- `app/_layout.tsx` — `DemoProvider` → `AppProvider`
- `app/modal.tsx` — mode toggle + display
- `app/(onboarding)/*.tsx` (5 files) — `useDemo()` → `useApp()`
- `app/(tabs)/*.tsx` (5 files) — `useDemo()` → `useApp()`

## Test Plan

- [ ] Run `./scripts/app/check` — passes
- [ ] Open app in demo mode — behaves identically to before
- [ ] Switch to live mode in Settings — app rebuilds without crash, stub messages appear
- [ ] Switch back to demo — demo state is fresh

---
🤖 agent-0708d554