### PR TITLE
feat(#9): LLM provider interface + OpenAI streaming adapter

### DIFF
--- a/apps/mobile/lib/agent-runtime/index.ts
+++ b/apps/mobile/lib/agent-runtime/index.ts
@@ -1,0 +1,23 @@
+export type {
+  ChatMessage,
+  ChatRole,
+  ChatStream,
+  LlmProvider,
+  ModelInfo,
+  ProviderConfig,
+  StreamChunk,
+  StreamOptions,
+} from "./types";
+
+export { createOpenAiProvider, ProviderError } from "./openai-adapter";
+
+export {
+  AVAILABLE_PROVIDERS,
+  clearApiKey,
+  createProvider,
+  hasApiKey,
+  loadApiKey,
+  loadProviderConfig,
+  saveApiKey,
+  saveProviderConfig,
+} from "./provider-store";

--- a/apps/mobile/lib/agent-runtime/openai-adapter.ts
+++ b/apps/mobile/lib/agent-runtime/openai-adapter.ts
@@ -1,0 +1,211 @@
+/**
+ * OpenAI adapter — streaming chat completions via SSE.
+ *
+ * The API key is injected at construction time (caller reads from SecureStore).
+ * No key is ever logged or included in error messages.
+ */
+
+import type {
+  ChatStream,
+  LlmProvider,
+  ModelInfo,
+  StreamChunk,
+  StreamOptions,
+} from "./types";
+
+const OPENAI_BASE = "https://api.openai.com/v1";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MODEL = "gpt-4o-mini";
+
+// ---------------------------------------------------------------------------
+// SSE line parser
+// ---------------------------------------------------------------------------
+
+function parseSseLine(line: string): StreamChunk | null {
+  if (!line.startsWith("data: ")) return null;
+  const data = line.slice(6).trim();
+  if (data === "[DONE]") return { type: "done", finishReason: "stop" };
+
+  try {
+    const json = JSON.parse(data);
+    const delta = json?.choices?.[0]?.delta;
+    const finishReason = json?.choices?.[0]?.finish_reason;
+
+    if (finishReason === "stop" || finishReason === "length") {
+      return { type: "done", finishReason };
+    }
+
+    const text = delta?.content;
+    if (typeof text === "string" && text.length > 0) {
+      return { type: "delta", text };
+    }
+  } catch {
+    // Malformed JSON — skip.
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming fetch
+// ---------------------------------------------------------------------------
+
+async function* streamSse(
+  url: string,
+  body: Record<string, unknown>,
+  apiKey: string,
+  timeoutMs: number,
+  signal: AbortSignal
+): AsyncGenerator<StreamChunk> {
+  const controller = new AbortController();
+  const combinedSignal = signal;
+
+  // Timeout via setTimeout
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const abortOnParent = () => controller.abort();
+  combinedSignal.addEventListener("abort", abortOnParent);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      // Scrub: never include apiKey in error messages.
+      const safeMsg = scrubApiKey(text, apiKey);
+      throw new ProviderError(`OpenAI API error (HTTP ${res.status})`, safeMsg);
+    }
+
+    if (!res.body) {
+      throw new ProviderError("OpenAI returned no response body", "");
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      // Keep incomplete last line in buffer.
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const chunk = parseSseLine(trimmed);
+        if (chunk) yield chunk;
+        if (chunk?.type === "done") return;
+      }
+    }
+
+    // Process any remaining buffer.
+    if (buffer.trim()) {
+      const chunk = parseSseLine(buffer.trim());
+      if (chunk) yield chunk;
+    }
+
+    // If we never received [DONE], emit one.
+    yield { type: "done", finishReason: "stop" };
+  } finally {
+    clearTimeout(timeoutId);
+    combinedSignal.removeEventListener("abort", abortOnParent);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export class ProviderError extends Error {
+  readonly detail: string;
+  constructor(message: string, detail: string) {
+    super(message);
+    this.name = "ProviderError";
+    this.detail = detail;
+  }
+}
+
+function scrubApiKey(text: string, apiKey: string): string {
+  if (!apiKey) return text;
+  return text.replaceAll(apiKey, "[REDACTED]");
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI provider
+// ---------------------------------------------------------------------------
+
+export function createOpenAiProvider(apiKey: string): LlmProvider {
+  if (!apiKey) {
+    throw new ProviderError("OpenAI API key is required", "");
+  }
+
+  return {
+    name: "OpenAI",
+    id: "openai",
+
+    streamChat(opts: StreamOptions): ChatStream {
+      const model = opts.model || DEFAULT_MODEL;
+      const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const abortController = new AbortController();
+
+      const messages = [
+        ...(opts.systemPrompt
+          ? [{ role: "system" as const, content: opts.systemPrompt }]
+          : []),
+        ...opts.messages.map((m) => ({ role: m.role, content: m.content })),
+      ];
+
+      const body: Record<string, unknown> = {
+        model,
+        messages,
+        stream: true,
+      };
+      if (opts.maxTokens != null) body.max_tokens = opts.maxTokens;
+      if (opts.temperature != null) body.temperature = opts.temperature;
+
+      const generator = streamSse(
+        `${OPENAI_BASE}/chat/completions`,
+        body,
+        apiKey,
+        timeoutMs,
+        abortController.signal
+      );
+
+      const stream: ChatStream = Object.assign(generator, {
+        cancel: () => abortController.abort(),
+      });
+
+      return stream;
+    },
+
+    async listModels(): Promise<ModelInfo[]> {
+      try {
+        const res = await fetch(`${OPENAI_BASE}/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (!res.ok) return [];
+
+        const json = (await res.json()) as { data?: Array<{ id: string }> };
+        return (json.data ?? [])
+          .filter((m) => m.id.startsWith("gpt-"))
+          .map((m) => ({ id: m.id, name: m.id }))
+          .sort((a, b) => a.id.localeCompare(b.id));
+      } catch {
+        return [];
+      }
+    },
+  };
+}

--- a/apps/mobile/lib/agent-runtime/provider-store.ts
+++ b/apps/mobile/lib/agent-runtime/provider-store.ts
@@ -1,0 +1,90 @@
+/**
+ * Provider configuration persistence.
+ *
+ * Stores the selected provider ID, model ID, and API key in SecureStore.
+ * The API key is NEVER logged, exported, or included in error messages.
+ */
+
+import { secureDelete, secureGet, secureSet } from "@/lib/storage/secure-store";
+
+import { createOpenAiProvider } from "./openai-adapter";
+import type { LlmProvider, ProviderConfig } from "./types";
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+const KEY_PROVIDER_CONFIG = "starkclaw.provider_config.v1";
+const KEY_API_KEY = "starkclaw.llm_api_key.v1";
+
+// ---------------------------------------------------------------------------
+// Config persistence
+// ---------------------------------------------------------------------------
+
+export async function loadProviderConfig(): Promise<ProviderConfig | null> {
+  const raw = await secureGet(KEY_PROVIDER_CONFIG);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const { providerId, modelId } = parsed as Record<string, unknown>;
+    if (typeof providerId !== "string" || typeof modelId !== "string") return null;
+    return { providerId, modelId };
+  } catch {
+    return null;
+  }
+}
+
+export async function saveProviderConfig(config: ProviderConfig): Promise<void> {
+  await secureSet(KEY_PROVIDER_CONFIG, JSON.stringify(config));
+}
+
+// ---------------------------------------------------------------------------
+// API key management
+// ---------------------------------------------------------------------------
+
+export async function loadApiKey(): Promise<string | null> {
+  return secureGet(KEY_API_KEY);
+}
+
+export async function saveApiKey(key: string): Promise<void> {
+  await secureSet(KEY_API_KEY, key);
+}
+
+export async function clearApiKey(): Promise<void> {
+  await secureDelete(KEY_API_KEY);
+}
+
+export async function hasApiKey(): Promise<boolean> {
+  const key = await secureGet(KEY_API_KEY);
+  return key !== null && key.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Provider factory
+// ---------------------------------------------------------------------------
+
+/** Known provider IDs. */
+export const AVAILABLE_PROVIDERS = [
+  { id: "openai", name: "OpenAI" },
+] as const;
+
+/**
+ * Create an LlmProvider instance from stored config + key.
+ * Returns null if no API key is stored or provider ID is unknown.
+ */
+export async function createProvider(): Promise<LlmProvider | null> {
+  const config = await loadProviderConfig();
+  const apiKey = await loadApiKey();
+
+  if (!apiKey) return null;
+
+  const providerId = config?.providerId ?? "openai";
+
+  switch (providerId) {
+    case "openai":
+      return createOpenAiProvider(apiKey);
+    default:
+      return null;
+  }
+}

--- a/apps/mobile/lib/agent-runtime/types.ts
+++ b/apps/mobile/lib/agent-runtime/types.ts
@@ -1,0 +1,75 @@
+/**
+ * LLM provider interface for the Starkclaw agent runtime.
+ *
+ * Providers must support streaming chat completions.
+ * The interface is intentionally minimal to allow multiple adapters.
+ */
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+export type ChatRole = "system" | "user" | "assistant";
+
+export type ChatMessage = {
+  role: ChatRole;
+  content: string;
+};
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+/** A single chunk emitted during streaming. */
+export type StreamChunk =
+  | { type: "delta"; text: string }
+  | { type: "done"; finishReason: "stop" | "length" | "error" };
+
+export type StreamOptions = {
+  /** Model ID to use (e.g. "gpt-4o-mini"). */
+  model: string;
+  /** System prompt prepended to the conversation. */
+  systemPrompt?: string;
+  /** Conversation messages. */
+  messages: ChatMessage[];
+  /** Max tokens to generate. Default: provider-specific. */
+  maxTokens?: number;
+  /** Sampling temperature. Default: provider-specific. */
+  temperature?: number;
+  /** Request timeout in ms. Default: 30000. */
+  timeoutMs?: number;
+};
+
+/** Async iterable of stream chunks. Call `cancel()` to abort early. */
+export type ChatStream = AsyncIterable<StreamChunk> & {
+  cancel: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+export type ModelInfo = {
+  id: string;
+  name: string;
+};
+
+export type LlmProvider = {
+  /** Human-readable provider name (e.g. "OpenAI"). */
+  readonly name: string;
+  /** Provider identifier used in config (e.g. "openai"). */
+  readonly id: string;
+  /** Start a streaming chat completion. */
+  streamChat: (opts: StreamOptions) => ChatStream;
+  /** List available models. Returns empty array on error. */
+  listModels: () => Promise<ModelInfo[]>;
+};
+
+// ---------------------------------------------------------------------------
+// Provider config (persisted to SecureStore)
+// ---------------------------------------------------------------------------
+
+export type ProviderConfig = {
+  providerId: string;
+  modelId: string;
+};


### PR DESCRIPTION
Closes #9

## Summary

- **`LlmProvider` interface** with `streamChat()` (async iterable of chunks), `listModels()`, and `cancel()`
- **OpenAI adapter** with SSE streaming, configurable timeout, abort support
- **Provider store** for config + API key persistence via SecureStore
- **API key security**: never logged, never in error messages, scrubbed from all outputs

## Architecture

```
lib/agent-runtime/
├── types.ts          — ChatMessage, StreamChunk, LlmProvider, ProviderConfig
├── openai-adapter.ts — SSE streaming, error handling, key scrubbing
├── provider-store.ts — SecureStore persistence, provider factory
└── index.ts          — barrel export
```

## Acceptance Criteria

- [x] Provider adapter can stream tokens to the UI (via async iterable)
- [x] API key stored in SecureStore, never written to logs
- [x] Requests have timeouts and clear error mapping
- [x] `./scripts/app/check` passes (typecheck + lint clean)

## Security

- API key injected at construction, never stored in module scope
- `scrubApiKey()` removes key from all error messages before they propagate
- `ProviderError` carries a safe `detail` string for UI display
- `clearApiKey()` deletes from SecureStore

## Test Plan

- [ ] Run `./scripts/app/check` — passes
- [ ] Import `createProvider()` — returns `null` when no API key stored
- [ ] After `saveApiKey()` + `saveProviderConfig()`, `createProvider()` returns valid provider
- [ ] `streamChat()` yields delta chunks and terminates with done chunk
- [ ] `cancel()` aborts the stream mid-response
- [ ] Error messages never contain the API key

---
🤖 agent-0708d554