### PR TITLE
feat(#12): tool runtime v0 — registry, schema validation, audit log

### DIFF
--- a/apps/mobile/lib/agent-runtime/tools/core-tools.ts
+++ b/apps/mobile/lib/agent-runtime/tools/core-tools.ts
@@ -1,0 +1,206 @@
+/**
+ * Core tool definitions for the MVP transfer flow.
+ *
+ * Tools:
+ *   get_balances     — Read ERC-20 balances for the wallet
+ *   prepare_transfer — Validate + prepare an ERC-20 transfer action
+ *   estimate_fee     — Stub: estimate gas for a prepared transfer
+ *   execute_transfer — Execute a prepared transfer via session key
+ *
+ * Each tool wraps existing live library functions and returns structured
+ * results that the model can reason about.
+ */
+
+import type { ToolDefinition, ToolResult } from "./types";
+
+// ---------------------------------------------------------------------------
+// get_balances
+// ---------------------------------------------------------------------------
+
+export const getBalancesTool: ToolDefinition = {
+  name: "get_balances",
+  description:
+    "Read the ERC-20 balances (ETH, USDC, STRK) for the connected wallet. Returns token symbols, raw balances, and human-readable amounts.",
+  argsSchema: {
+    type: "object",
+    properties: {
+      network: {
+        type: "string",
+        description: "Network to query.",
+        enum: ["sepolia", "mainnet"],
+      },
+    },
+    required: ["network"],
+  },
+  async handler(args): Promise<ToolResult> {
+    const network = args.network as string;
+    // Stub: live implementation will call getErc20Balance for each token.
+    return {
+      ok: true,
+      data: {
+        network,
+        balances: [
+          { symbol: "ETH", amount: "0", formatted: "0 ETH" },
+          { symbol: "USDC", amount: "0", formatted: "0 USDC" },
+          { symbol: "STRK", amount: "0", formatted: "0 STRK" },
+        ],
+        note: "Live balance fetching will be wired when wallet lifecycle (#3) lands.",
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// prepare_transfer
+// ---------------------------------------------------------------------------
+
+export const prepareTransferTool: ToolDefinition = {
+  name: "prepare_transfer",
+  description:
+    "Validate and prepare an ERC-20 transfer. Returns the transfer action with policy checks and warnings. Does NOT execute.",
+  argsSchema: {
+    type: "object",
+    properties: {
+      tokenSymbol: {
+        type: "string",
+        description: "Token to transfer.",
+        enum: ["ETH", "USDC", "STRK"],
+      },
+      amount: {
+        type: "string",
+        description: "Amount to transfer in human-readable units (e.g. '2.5').",
+      },
+      to: {
+        type: "string",
+        description: "Recipient Starknet address (0x-prefixed hex).",
+      },
+    },
+    required: ["tokenSymbol", "amount", "to"],
+  },
+  async handler(args): Promise<ToolResult> {
+    const { tokenSymbol, amount, to } = args as Record<string, string>;
+
+    // Basic input validation.
+    if (!/^0x[0-9a-fA-F]+$/.test(to)) {
+      return { ok: false, error: "Invalid recipient address. Must be 0x-prefixed hex." };
+    }
+    const numAmount = Number(amount);
+    if (!Number.isFinite(numAmount) || numAmount <= 0) {
+      return { ok: false, error: "Amount must be a positive number." };
+    }
+
+    // Stub: live implementation will call prepareTransferFromText.
+    return {
+      ok: true,
+      data: {
+        kind: "erc20_transfer",
+        tokenSymbol,
+        amount,
+        to,
+        warnings: [],
+        note: "Live transfer preparation will be wired when wallet lifecycle (#3) and session keys (#6) land.",
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// estimate_fee
+// ---------------------------------------------------------------------------
+
+export const estimateFeeTool: ToolDefinition = {
+  name: "estimate_fee",
+  description:
+    "Estimate the gas fee for a prepared transfer. Returns the estimated fee in STRK.",
+  argsSchema: {
+    type: "object",
+    properties: {
+      tokenSymbol: {
+        type: "string",
+        description: "Token being transferred.",
+        enum: ["ETH", "USDC", "STRK"],
+      },
+      amount: {
+        type: "string",
+        description: "Amount being transferred.",
+      },
+      to: {
+        type: "string",
+        description: "Recipient address.",
+      },
+    },
+    required: ["tokenSymbol", "amount", "to"],
+  },
+  async handler(): Promise<ToolResult> {
+    // Stub: live implementation will simulate the transaction.
+    return {
+      ok: true,
+      data: {
+        estimatedFeeStrk: "0.001",
+        estimatedFeeUsd: "$0.002",
+        note: "Live fee estimation will be wired when account deployment (#5) lands.",
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// execute_transfer
+// ---------------------------------------------------------------------------
+
+export const executeTransferTool: ToolDefinition = {
+  name: "execute_transfer",
+  description:
+    "Execute a prepared ERC-20 transfer using a session key. Returns the transaction hash.",
+  argsSchema: {
+    type: "object",
+    properties: {
+      tokenSymbol: {
+        type: "string",
+        description: "Token to transfer.",
+        enum: ["ETH", "USDC", "STRK"],
+      },
+      amount: {
+        type: "string",
+        description: "Amount to transfer.",
+      },
+      to: {
+        type: "string",
+        description: "Recipient address.",
+      },
+    },
+    required: ["tokenSymbol", "amount", "to"],
+  },
+  async handler(args): Promise<ToolResult> {
+    const { tokenSymbol, amount, to } = args as Record<string, string>;
+
+    // Basic input validation.
+    if (!/^0x[0-9a-fA-F]+$/.test(to)) {
+      return { ok: false, error: "Invalid recipient address." };
+    }
+
+    // Stub: live implementation will call executeTransfer from lib/agent/transfer.ts.
+    return {
+      ok: true,
+      data: {
+        txHash: null,
+        tokenSymbol,
+        amount,
+        to,
+        status: "stubbed",
+        note: "Live transfer execution will be wired when session keys (#6) land.",
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// All core tools
+// ---------------------------------------------------------------------------
+
+export const CORE_TOOLS: ToolDefinition[] = [
+  getBalancesTool,
+  prepareTransferTool,
+  estimateFeeTool,
+  executeTransferTool,
+];

--- a/apps/mobile/lib/agent-runtime/tools/index.ts
+++ b/apps/mobile/lib/agent-runtime/tools/index.ts
@@ -1,0 +1,29 @@
+export type { AuditEntry, JsonSchema, ToolDefinition, ToolResult } from "./types";
+
+export {
+  clearAuditLog,
+  executeTool,
+  getAuditLog,
+  getTool,
+  listTools,
+  registerTool,
+} from "./registry";
+
+export {
+  CORE_TOOLS,
+  estimateFeeTool,
+  executeTransferTool,
+  getBalancesTool,
+  prepareTransferTool,
+} from "./core-tools";
+
+// ---------------------------------------------------------------------------
+// Boot — register all core tools on import.
+// ---------------------------------------------------------------------------
+
+import { registerTool } from "./registry";
+import { CORE_TOOLS } from "./core-tools";
+
+for (const tool of CORE_TOOLS) {
+  registerTool(tool);
+}

--- a/apps/mobile/lib/agent-runtime/tools/registry.ts
+++ b/apps/mobile/lib/agent-runtime/tools/registry.ts
@@ -1,0 +1,185 @@
+/**
+ * Tool registry — strict allowlist with schema validation and audit logging.
+ *
+ * Unknown tools are rejected. Invalid args are rejected with a safe error.
+ * Every call is logged to a persistent audit trail.
+ */
+
+import { secureGet, secureSet } from "@/lib/storage/secure-store";
+
+import type { AuditEntry, JsonSchema, ToolDefinition, ToolResult } from "./types";
+
+const AUDIT_STORAGE_KEY = "starkclaw.tool_audit.v1";
+const MAX_AUDIT_ENTRIES = 200;
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const tools = new Map<string, ToolDefinition>();
+
+export function registerTool(def: ToolDefinition): void {
+  tools.set(def.name, def);
+}
+
+export function listTools(): ToolDefinition[] {
+  return Array.from(tools.values());
+}
+
+export function getTool(name: string): ToolDefinition | undefined {
+  return tools.get(name);
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation (minimal but sufficient for flat objects)
+// ---------------------------------------------------------------------------
+
+function validateArgs(args: unknown, schema: JsonSchema): string | null {
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return "Arguments must be a plain object.";
+  }
+
+  const obj = args as Record<string, unknown>;
+
+  // Check required fields.
+  for (const key of schema.required ?? []) {
+    if (!(key in obj) || obj[key] === undefined || obj[key] === null) {
+      return `Missing required argument: "${key}".`;
+    }
+  }
+
+  // Check types for provided fields.
+  for (const [key, propSchema] of Object.entries(schema.properties)) {
+    const value = obj[key];
+    if (value === undefined || value === null) continue;
+
+    if (propSchema.type === "string" && typeof value !== "string") {
+      return `Argument "${key}" must be a string.`;
+    }
+    if (propSchema.type === "number" && typeof value !== "number") {
+      return `Argument "${key}" must be a number.`;
+    }
+    if (propSchema.type === "boolean" && typeof value !== "boolean") {
+      return `Argument "${key}" must be a boolean.`;
+    }
+
+    if (propSchema.enum && typeof value === "string" && !propSchema.enum.includes(value)) {
+      return `Argument "${key}" must be one of: ${propSchema.enum.join(", ")}.`;
+    }
+  }
+
+  // Reject unknown keys.
+  for (const key of Object.keys(obj)) {
+    if (!(key in schema.properties)) {
+      return `Unknown argument: "${key}".`;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_KEYS = new Set([
+  "privateKey",
+  "private_key",
+  "apiKey",
+  "api_key",
+  "secret",
+  "password",
+  "mnemonic",
+  "seed",
+]);
+
+function redactArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    out[k] = SENSITIVE_KEYS.has(k) ? "[REDACTED]" : v;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+async function loadAuditLog(): Promise<AuditEntry[]> {
+  const raw = await secureGet(AUDIT_STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as AuditEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function appendAuditEntry(entry: AuditEntry): Promise<void> {
+  const log = await loadAuditLog();
+  log.unshift(entry);
+  // Trim to max size.
+  const trimmed = log.slice(0, MAX_AUDIT_ENTRIES);
+  await secureSet(AUDIT_STORAGE_KEY, JSON.stringify(trimmed)).catch(() => {});
+}
+
+export async function getAuditLog(): Promise<AuditEntry[]> {
+  return loadAuditLog();
+}
+
+export async function clearAuditLog(): Promise<void> {
+  await secureSet(AUDIT_STORAGE_KEY, "[]").catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Execute
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a tool by name with the given arguments.
+ *
+ * - Unknown tools are rejected.
+ * - Invalid args are rejected with a safe error.
+ * - Every call is logged to the audit trail.
+ */
+export async function executeTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  const def = tools.get(name);
+  if (!def) {
+    return { ok: false, error: `Unknown tool: "${name}". Available: ${Array.from(tools.keys()).join(", ")}.` };
+  }
+
+  const validationError = validateArgs(args, def.argsSchema);
+  if (validationError) {
+    return { ok: false, error: validationError };
+  }
+
+  const start = Date.now();
+  let result: ToolResult;
+  try {
+    result = await def.handler(args);
+  } catch (err) {
+    result = {
+      ok: false,
+      error: err instanceof Error ? err.message : "Tool execution failed.",
+    };
+  }
+  const durationMs = Date.now() - start;
+
+  const entry: AuditEntry = {
+    id: `tool_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`,
+    timestamp: Math.floor(Date.now() / 1000),
+    toolName: name,
+    args: redactArgs(args),
+    result,
+    durationMs,
+  };
+
+  // Fire and forget — don't block the caller.
+  appendAuditEntry(entry).catch(() => {});
+
+  return result;
+}

--- a/apps/mobile/lib/agent-runtime/tools/types.ts
+++ b/apps/mobile/lib/agent-runtime/tools/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Tool runtime types.
+ *
+ * Every tool is defined by a JSON-schema for its arguments, a handler,
+ * and metadata for display. The runtime validates inputs before execution
+ * and logs every call to a persistent audit log.
+ */
+
+// ---------------------------------------------------------------------------
+// Tool definition
+// ---------------------------------------------------------------------------
+
+/** JSON Schema subset sufficient for flat tool arguments. */
+export type JsonSchema = {
+  type: "object";
+  properties: Record<string, { type: string; description?: string; enum?: string[] }>;
+  required?: string[];
+};
+
+export type ToolResult =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string };
+
+export type ToolDefinition = {
+  /** Machine-readable tool name (e.g. "get_balances"). */
+  name: string;
+  /** Human-readable description shown to the model. */
+  description: string;
+  /** JSON Schema for validating the tool's arguments. */
+  argsSchema: JsonSchema;
+  /** Execute the tool. Must never throw — returns ToolResult. */
+  handler: (args: Record<string, unknown>) => Promise<ToolResult>;
+};
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+export type AuditEntry = {
+  id: string;
+  timestamp: number;
+  toolName: string;
+  /** Redacted copy of the arguments (secrets stripped). */
+  args: Record<string, unknown>;
+  result: ToolResult;
+  durationMs: number;
+};


### PR DESCRIPTION
Closes #12

## Summary

- **Tool registry** with strict allowlist — unknown tools rejected with safe error
- **Schema validation** via JSON Schema for all tool arguments (required fields, types, enums, unknown key rejection)
- **Core MVP tools** (stubbed, ready to wire):
  - `get_balances` — read ERC-20 balances
  - `prepare_transfer` — validate + prepare transfer action
  - `estimate_fee` — estimate gas for a transfer
  - `execute_transfer` — execute via session key
- **Audit log** persisted to SecureStore with redaction of sensitive keys

## Architecture

```
lib/agent-runtime/tools/
├── types.ts      — ToolDefinition, JsonSchema, AuditEntry, ToolResult
├── registry.ts   — Tool registry, schema validator, audit log, executeTool()
├── core-tools.ts — get_balances, prepare_transfer, estimate_fee, execute_transfer
└── index.ts      — barrel export + auto-registration of core tools
```

## Security

- Unknown tool names rejected: `"Unknown tool: 'foo'. Available: get_balances, ..."`
- Invalid args rejected: `"Missing required argument: 'tokenSymbol'"`
- Sensitive keys (`privateKey`, `apiKey`, `secret`, etc.) redacted in audit log
- Tools return `ToolResult` (ok/error) — never throw
- Audit log capped at 200 entries

## Acceptance Criteria

- [x] Unknown tools are rejected
- [x] Invalid args are rejected with a safe error
- [x] Tool calls/results are persisted and exportable (without secrets)
- [x] `./scripts/app/check` passes

## Test Plan

- [ ] `executeTool("unknown_tool", {})` returns error with available tools list
- [ ] `executeTool("get_balances", {})` returns error for missing `network`
- [ ] `executeTool("get_balances", { network: "sepolia" })` returns ok with stub data
- [ ] `getAuditLog()` shows persisted entries with redacted args
- [ ] `clearAuditLog()` wipes the log

---
🤖 agent-0708d554