### PR TITLE
feat(#10): chat UI — streaming message + tool-call card

### DIFF
--- a/apps/mobile/ui/chat/index.ts
+++ b/apps/mobile/ui/chat/index.ts
@@ -1,0 +1,2 @@
+export { StreamingMessage } from "./streaming-message";
+export { ToolCallCard } from "./tool-call-card";

--- a/apps/mobile/ui/chat/streaming-message.tsx
+++ b/apps/mobile/ui/chat/streaming-message.tsx
@@ -1,0 +1,113 @@
+/**
+ * StreamingMessage — renders assistant tokens as they arrive.
+ *
+ * Accepts a `text` prop that grows over time (caller appends deltas).
+ * Shows a blinking cursor while streaming and fades it out on completion.
+ * Includes a cancel button to abort the stream.
+ */
+
+import * as React from "react";
+import { View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+
+import { useAppTheme } from "@/ui/app-theme";
+import { Chip } from "@/ui/chip";
+import { haptic } from "@/ui/haptics";
+import { Row } from "@/ui/screen";
+import { Body, Muted } from "@/ui/typography";
+
+type Props = {
+  /** The accumulated text so far (caller appends deltas). */
+  text: string;
+  /** Whether tokens are still arriving. */
+  streaming: boolean;
+  /** Called when the user taps "Stop". */
+  onCancel?: () => void;
+};
+
+function BlinkingCursor() {
+  const t = useAppTheme();
+  const opacity = useSharedValue(1);
+
+  React.useEffect(() => {
+    opacity.value = withRepeat(withTiming(0.2, { duration: 500 }), -1, true);
+  }, [opacity]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width: 8,
+          height: 18,
+          borderRadius: 2,
+          backgroundColor: t.colors.accent2,
+          marginLeft: 2,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+export function StreamingMessage(props: Props) {
+  const t = useAppTheme();
+
+  const borderA = t.scheme === "dark" ? "rgba(255,255,255,0.20)" : "rgba(255,255,255,0.92)";
+  const borderB = t.scheme === "dark" ? "rgba(255,255,255,0.08)" : "rgba(8,18,32,0.10)";
+  const fill = t.scheme === "dark" ? "rgba(255,255,255,0.05)" : "rgba(255,255,255,0.60)";
+
+  return (
+    <View style={{ alignSelf: "flex-start", maxWidth: "92%" }}>
+      <LinearGradient
+        colors={[borderA, borderB]}
+        start={{ x: 0.1, y: 0.0 }}
+        end={{ x: 0.9, y: 1 }}
+        style={{ borderRadius: 20, borderCurve: "continuous", padding: 1 }}
+      >
+        <View
+          style={{
+            paddingVertical: 10,
+            paddingHorizontal: 12,
+            borderRadius: 19,
+            borderCurve: "continuous",
+            borderWidth: 1,
+            borderColor: t.colors.glassBorder,
+            backgroundColor: fill,
+          }}
+        >
+          <View style={{ gap: 8 }}>
+            <View style={{ flexDirection: "row", flexWrap: "wrap", alignItems: "flex-end" }}>
+              <Body style={{ color: t.colors.text }}>
+                {props.text || (props.streaming ? "" : "...")}
+              </Body>
+              {props.streaming ? <BlinkingCursor /> : null}
+            </View>
+
+            {props.streaming && props.onCancel ? (
+              <Row>
+                <Muted>Streaming</Muted>
+                <Chip
+                  label="Stop"
+                  onPress={async () => {
+                    await haptic("tap");
+                    props.onCancel?.();
+                  }}
+                />
+              </Row>
+            ) : null}
+          </View>
+        </View>
+      </LinearGradient>
+    </View>
+  );
+}

--- a/apps/mobile/ui/chat/tool-call-card.tsx
+++ b/apps/mobile/ui/chat/tool-call-card.tsx
@@ -1,0 +1,130 @@
+/**
+ * ToolCallCard — structured visualization of a tool call event.
+ *
+ * Shows tool name, scrubbed parameters, result summary, duration, and timestamp.
+ * Uses the glass design system with accent colors for read vs write operations.
+ */
+
+import * as React from "react";
+import { View } from "react-native";
+
+import { AppIcon } from "@/ui/app-icon";
+import { Badge } from "@/ui/badge";
+import { GlassCard } from "@/ui/glass-card";
+import { useAppTheme } from "@/ui/app-theme";
+import { Row } from "@/ui/screen";
+import { Body, Mono, Muted } from "@/ui/typography";
+
+type ToolCallStatus = "running" | "success" | "error";
+
+type Props = {
+  /** Tool name (e.g. "get_balances"). */
+  toolName: string;
+  /** Scrubbed parameter key-value pairs for display. */
+  params: Record<string, string>;
+  /** Result summary (null while running). */
+  resultSummary: string | null;
+  /** Execution status. */
+  status: ToolCallStatus;
+  /** Duration in ms (null while running). */
+  durationMs: number | null;
+  /** ISO timestamp string. */
+  timestamp: string;
+  /** Whether this is a read-only or mutating operation. */
+  kind: "read" | "write";
+};
+
+function statusBadge(status: ToolCallStatus): { label: string; tone: "good" | "danger" | "neutral" } {
+  switch (status) {
+    case "success":
+      return { label: "Done", tone: "good" };
+    case "error":
+      return { label: "Error", tone: "danger" };
+    case "running":
+      return { label: "Running", tone: "neutral" };
+  }
+}
+
+export function ToolCallCard(props: Props) {
+  const t = useAppTheme();
+  const badge = statusBadge(props.status);
+
+  const iconName = props.kind === "read" ? "magnifyingglass" : "arrow.right.circle.fill";
+  const faIcon = props.kind === "read" ? "search" : "arrow-circle-right";
+
+  return (
+    <GlassCard padding={14} intensity={t.scheme === "dark" ? 18 : 55}>
+      <View style={{ gap: 10 }}>
+        <Row>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+            <View
+              style={{
+                width: 30,
+                height: 30,
+                borderRadius: 10,
+                borderCurve: "continuous",
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor:
+                  props.kind === "read"
+                    ? t.scheme === "dark"
+                      ? "rgba(90,169,255,0.14)"
+                      : "rgba(36,87,255,0.12)"
+                    : t.scheme === "dark"
+                      ? "rgba(255,159,10,0.14)"
+                      : "rgba(255,159,10,0.12)",
+                borderWidth: 1,
+                borderColor: t.colors.glassBorder,
+              }}
+            >
+              <AppIcon
+                ios={iconName}
+                fa={faIcon}
+                color={props.kind === "read" ? t.colors.accent2 : t.colors.warn}
+                size={16}
+              />
+            </View>
+            <Body style={{ fontFamily: t.font.bodyMedium }}>
+              {props.toolName.replace(/_/g, " ")}
+            </Body>
+          </View>
+          <Badge label={badge.label} tone={badge.tone} />
+        </Row>
+
+        {Object.keys(props.params).length > 0 ? (
+          <View style={{ gap: 4 }}>
+            {Object.entries(props.params).map(([key, value]) => (
+              <Row key={key}>
+                <Muted>{key}</Muted>
+                <Mono style={{ color: t.colors.text }}>{value}</Mono>
+              </Row>
+            ))}
+          </View>
+        ) : null}
+
+        {props.resultSummary ? (
+          <View
+            style={{
+              paddingVertical: 8,
+              paddingHorizontal: 10,
+              borderRadius: 12,
+              borderCurve: "continuous",
+              backgroundColor: t.scheme === "dark" ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.03)",
+            }}
+          >
+            <Body style={{ color: props.status === "error" ? t.colors.bad : t.colors.text }}>
+              {props.resultSummary}
+            </Body>
+          </View>
+        ) : null}
+
+        <Row>
+          <Muted>{props.timestamp}</Muted>
+          {props.durationMs != null ? (
+            <Muted>{props.durationMs}ms</Muted>
+          ) : null}
+        </Row>
+      </View>
+    </GlassCard>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #10.

Adds reusable chat components in `ui/chat/`:

- **`StreamingMessage`** — renders assistant tokens as they arrive with a blinking cursor (Reanimated), glass-bordered bubble matching the design system, and a cancel button (Chip) to abort the stream
- **`ToolCallCard`** — structured visualization of tool-call events showing tool name, scrubbed parameter key-value pairs, result summary, execution status badge, duration, timestamp, and read/write accent distinction (blue for reads, orange for writes)
- **Barrel export** `ui/chat/index.ts`

Both components are standalone from provider integration — they accept generic props and can be composed into a chat screen by a future PR that wires up the agent runtime.

### Design decisions

- Uses existing glass design system: `GlassCard`, `Badge`, `Chip`, `LinearGradient` border, `AppIcon`
- `StreamingMessage` accepts the accumulated text (caller appends deltas), not the stream itself — keeps the component pure and testable
- `ToolCallCard` has a `kind` prop (`"read"` | `"write"`) to visually distinguish read-only vs mutating operations
- No new dependencies — uses existing `expo-linear-gradient`, `react-native-reanimated`, and design system components

### Checks

- `npm run typecheck` ✅
- `npm run lint` ✅

🤖 agent-0708d554