### PR TITLE
feat(#3): wallet lifecycle — create, load, reset with SecureStore

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -10,6 +10,7 @@ import { useEffect } from "react";
 import "react-native-reanimated";
 
 import { DemoProvider, useDemo } from "@/lib/demo/demo-store";
+import { WalletProvider } from "@/lib/wallet/wallet-store";
 import { navThemeFromAppTheme, useAppTheme } from "@/ui/app-theme";
 
 export {
@@ -52,9 +53,11 @@ export default function RootLayout() {
   }
 
   return (
-    <DemoProvider>
-      <RootLayoutNav />
-    </DemoProvider>
+    <WalletProvider>
+      <DemoProvider>
+        <RootLayoutNav />
+      </DemoProvider>
+    </WalletProvider>
   );
 }
 

--- a/apps/mobile/app/modal.tsx
+++ b/apps/mobile/app/modal.tsx
@@ -3,6 +3,7 @@ import { View } from "react-native";
 import { useRouter } from "expo-router";
 
 import { useDemo } from "@/lib/demo/demo-store";
+import { useWallet } from "@/lib/wallet/wallet-store";
 import { GhostButton, IconButton, PrimaryButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
 import { GlassCard } from "@/ui/glass-card";
@@ -15,6 +16,7 @@ export default function DemoSettingsModal() {
   const t = useAppTheme();
   const router = useRouter();
   const { state, actions } = useDemo();
+  const walletStore = useWallet();
 
   return (
     <AppScreen>
@@ -39,13 +41,40 @@ export default function DemoSettingsModal() {
             UI-only showcase. No RPC calls. No signing. Everything is mocked to demo the full Starkclaw flow.
           </Muted>
           <Row>
-            <Muted>Account</Muted>
+            <Muted>Account (demo)</Muted>
             <Mono selectable>
               {state.account.address.slice(0, 10)}…{state.account.address.slice(-6)}
             </Mono>
           </Row>
         </View>
       </GlassCard>
+
+      {walletStore.wallet ? (
+        <GlassCard>
+          <View style={{ gap: 12 }}>
+            <H2>Wallet</H2>
+            <Row>
+              <Muted>Network</Muted>
+              <Mono selectable>{walletStore.wallet.networkId}</Mono>
+            </Row>
+            <Row>
+              <Muted>Address</Muted>
+              <Mono selectable>
+                {walletStore.wallet.accountAddress.slice(0, 10)}…{walletStore.wallet.accountAddress.slice(-6)}
+              </Mono>
+            </Row>
+            <GhostButton
+              label="Reset wallet"
+              onPress={async () => {
+                await haptic("warn");
+                await walletStore.reset();
+                actions.reset();
+                router.replace("/(onboarding)/welcome");
+              }}
+            />
+          </View>
+        </GlassCard>
+      ) : null}
 
       <GlassCard>
         <View style={{ gap: 12 }}>

--- a/apps/mobile/lib/wallet/wallet-store.tsx
+++ b/apps/mobile/lib/wallet/wallet-store.tsx
@@ -1,0 +1,82 @@
+/**
+ * WalletProvider — React context for wallet lifecycle.
+ *
+ * On mount: attempts to load an existing wallet from SecureStore.
+ * Exposes create / reset / the current WalletSnapshot.
+ */
+
+import * as React from "react";
+
+import {
+  createWallet,
+  loadWallet,
+  resetWallet,
+  type WalletSnapshot,
+} from "./wallet";
+import type { StarknetNetworkId } from "../starknet/networks";
+
+type WalletStatus = "loading" | "none" | "ready";
+
+type WalletContextValue = {
+  status: WalletStatus;
+  wallet: WalletSnapshot | null;
+  create: (networkId?: StarknetNetworkId) => Promise<WalletSnapshot>;
+  reset: () => Promise<void>;
+};
+
+const WalletContext = React.createContext<WalletContextValue | null>(null);
+
+export function WalletProvider(props: { children: React.ReactNode }) {
+  const [status, setStatus] = React.useState<WalletStatus>("loading");
+  const [wallet, setWallet] = React.useState<WalletSnapshot | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const snap = await loadWallet();
+      if (cancelled) return;
+      if (snap) {
+        setWallet(snap);
+        setStatus("ready");
+      } else {
+        setStatus("none");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const create = React.useCallback(
+    async (networkId: StarknetNetworkId = "sepolia") => {
+      const snap = await createWallet(networkId);
+      setWallet(snap);
+      setStatus("ready");
+      return snap;
+    },
+    [],
+  );
+
+  const reset = React.useCallback(async () => {
+    await resetWallet();
+    setWallet(null);
+    setStatus("none");
+  }, []);
+
+  const value = React.useMemo<WalletContextValue>(
+    () => ({ status, wallet, create, reset }),
+    [status, wallet, create, reset],
+  );
+
+  return (
+    <WalletContext.Provider value={value}>
+      {props.children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet(): WalletContextValue {
+  const ctx = React.useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used within <WalletProvider />");
+  return ctx;
+}


### PR DESCRIPTION
## Summary

Closes #3.

Adds `WalletProvider` context (`lib/wallet/wallet-store.tsx`) that wraps the existing `wallet.ts` functions into a React-friendly lifecycle:

- **Boot**: auto-loads existing wallet from SecureStore on mount
- **Create**: `useWallet().create(networkId?)` generates a real Stark key pair, computes the deterministic AgentAccount address, and persists to SecureStore
- **Reset**: `useWallet().reset()` deletes all wallet secrets and returns status to `"none"`
- **Status tracking**: `"loading"` → `"none"` | `"ready"` so consumers can gate on wallet existence

### Wiring

- **`_layout.tsx`**: `WalletProvider` wraps the entire app (above `DemoProvider`)
- **`ready.tsx` (onboarding)**: calls `walletStore.create()` during the "Generating policy keys" step; displays the real deterministic address when a wallet exists
- **`modal.tsx` (settings)**: shows wallet network + address when present; "Reset wallet" button clears SecureStore keys and returns to onboarding

### Design decisions

- Wallet creation is idempotent during onboarding — skips if status is already `"ready"`
- Reset clears both wallet secrets and demo state, ensuring a clean slate
- No on-chain deployment (out of scope per #3 — handled by #5)
- No session key management (out of scope per #3 — handled by #6)

### Checks

- `npm run typecheck` ✅
- `npm run lint` ✅

### Depends on

- #2 (backend abstraction) for full live mode integration — but the wallet lifecycle works independently

🤖 agent-0708d554