### PR TITLE
feat(#5): deploy AgentAccount from app (fund-first, deploy-later)

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -10,6 +10,7 @@ import { useEffect } from "react";
 import "react-native-reanimated";
 
 import { DemoProvider, useDemo } from "@/lib/demo/demo-store";
+import { WalletProvider } from "@/lib/wallet/wallet-store";
 import { navThemeFromAppTheme, useAppTheme } from "@/ui/app-theme";
 
 export {
@@ -52,9 +53,11 @@ export default function RootLayout() {
   }
 
   return (
-    <DemoProvider>
-      <RootLayoutNav />
-    </DemoProvider>
+    <WalletProvider>
+      <DemoProvider>
+        <RootLayoutNav />
+      </DemoProvider>
+    </WalletProvider>
   );
 }
 

--- a/apps/mobile/app/modal.tsx
+++ b/apps/mobile/app/modal.tsx
@@ -3,18 +3,23 @@ import { View } from "react-native";
 import { useRouter } from "expo-router";
 
 import { useDemo } from "@/lib/demo/demo-store";
+import { useWallet } from "@/lib/wallet/wallet-store";
+import { useDeployStatus } from "@/lib/wallet/use-deploy-status";
 import { GhostButton, IconButton, PrimaryButton } from "@/ui/buttons";
 import { AppIcon } from "@/ui/app-icon";
+import { Badge } from "@/ui/badge";
 import { GlassCard } from "@/ui/glass-card";
 import { haptic } from "@/ui/haptics";
 import { useAppTheme } from "@/ui/app-theme";
 import { AppScreen, Row } from "@/ui/screen";
-import { H1, H2, Mono, Muted } from "@/ui/typography";
+import { Body, H1, H2, Mono, Muted } from "@/ui/typography";
 
 export default function DemoSettingsModal() {
   const t = useAppTheme();
   const router = useRouter();
   const { state, actions } = useDemo();
+  const walletStore = useWallet();
+  const deployStatus = useDeployStatus(walletStore.wallet);
 
   return (
     <AppScreen>
@@ -46,6 +51,75 @@ export default function DemoSettingsModal() {
           </Row>
         </View>
       </GlassCard>
+
+      {walletStore.wallet ? (
+        <GlassCard>
+          <View style={{ gap: 12 }}>
+            <Row>
+              <H2>Agent account</H2>
+              <Badge
+                label={
+                  deployStatus.phase === "deployed" ? "Deployed"
+                    : deployStatus.phase === "deploying" ? "Deploying"
+                    : deployStatus.phase === "ready" ? "Ready"
+                    : deployStatus.phase === "needs-funding" ? "Needs funding"
+                    : "Checking"
+                }
+                tone={
+                  deployStatus.phase === "deployed" ? "good"
+                    : deployStatus.phase === "deploying" ? "warn"
+                    : deployStatus.phase === "ready" ? "accent"
+                    : "neutral"
+                }
+              />
+            </Row>
+
+            <Row>
+              <Muted>Address</Muted>
+              <Mono selectable>
+                {walletStore.wallet.accountAddress.slice(0, 10)}…{walletStore.wallet.accountAddress.slice(-6)}
+              </Mono>
+            </Row>
+            <Row>
+              <Muted>Network</Muted>
+              <Mono>{walletStore.wallet.networkId}</Mono>
+            </Row>
+
+            {deployStatus.fundingMessage ? (
+              <View style={{ gap: 8 }}>
+                <Body style={{ color: t.colors.warn }}>{deployStatus.fundingMessage}</Body>
+                {walletStore.wallet.networkId === "sepolia" ? (
+                  <Muted>Copy the address above and use the Starknet Sepolia faucet to fund it.</Muted>
+                ) : null}
+                <GhostButton label="Check again" onPress={deployStatus.checkFunding} />
+              </View>
+            ) : null}
+
+            {deployStatus.error ? (
+              <Body style={{ color: t.colors.bad }}>{deployStatus.error}</Body>
+            ) : null}
+
+            {deployStatus.phase === "ready" ? (
+              <PrimaryButton
+                label="Deploy account"
+                onPress={async () => {
+                  await haptic("tap");
+                  await deployStatus.deploy();
+                }}
+              />
+            ) : null}
+
+            {deployStatus.deployTxHash ? (
+              <Row>
+                <Muted>Deploy tx</Muted>
+                <Mono selectable style={{ fontSize: 11 }}>
+                  {deployStatus.deployTxHash.slice(0, 14)}…{deployStatus.deployTxHash.slice(-8)}
+                </Mono>
+              </Row>
+            ) : null}
+          </View>
+        </GlassCard>
+      ) : null}
 
       <GlassCard>
         <View style={{ gap: 12 }}>

--- a/apps/mobile/lib/starknet/deploy.ts
+++ b/apps/mobile/lib/starknet/deploy.ts
@@ -1,0 +1,99 @@
+/**
+ * deploy — deploys the AgentAccount contract for a wallet.
+ *
+ * Uses DEPLOY_ACCOUNT_v3 via starknet.js. The address must already
+ * have enough ETH/STRK to cover gas (fund-first, deploy-later).
+ */
+
+import { Account, hash } from "starknet";
+
+import { AGENT_ACCOUNT_CLASS_HASH } from "./contracts";
+import { getErc20Balance } from "./balances";
+import { isContractDeployed } from "./rpc";
+import { TOKENS } from "./tokens";
+import type { StarknetNetworkId } from "./networks";
+import type { WalletSnapshot } from "../wallet/wallet";
+import { loadOwnerPrivateKey, saveDeployTxHash } from "../wallet/wallet";
+import { appendActivity } from "../activity/activity";
+
+export type DeployCheckResult =
+  | { canDeploy: false; reason: string }
+  | { canDeploy: true };
+
+/**
+ * Check whether the account has enough funds and is not yet deployed.
+ */
+export async function checkDeployReadiness(
+  wallet: WalletSnapshot,
+): Promise<DeployCheckResult> {
+  const deployed = await isContractDeployed(wallet.rpcUrl, wallet.accountAddress);
+  if (deployed) {
+    return { canDeploy: false, reason: "Account is already deployed." };
+  }
+
+  // Check ETH and STRK balance — need at least one for gas.
+  const ethToken = TOKENS.find((t) => t.symbol === "ETH")!;
+  const strkToken = TOKENS.find((t) => t.symbol === "STRK")!;
+
+  const ethBalance = await getErc20Balance(
+    wallet.rpcUrl,
+    ethToken.addressByNetwork[wallet.networkId],
+    wallet.accountAddress,
+  );
+  const strkBalance = await getErc20Balance(
+    wallet.rpcUrl,
+    strkToken.addressByNetwork[wallet.networkId],
+    wallet.accountAddress,
+  );
+
+  // Require at least 0.001 ETH or 0.1 STRK for deployment gas.
+  const hasEth = ethBalance >= 1_000_000_000_000_000n; // 0.001 ETH
+  const hasStrk = strkBalance >= 100_000_000_000_000_000n; // 0.1 STRK
+
+  if (!hasEth && !hasStrk) {
+    return {
+      canDeploy: false,
+      reason: "Account needs funding. Send at least 0.001 ETH or 0.1 STRK to the address first.",
+    };
+  }
+
+  return { canDeploy: true };
+}
+
+/**
+ * Deploy the AgentAccount contract.
+ * Returns the deploy tx hash.
+ */
+export async function deployAgentAccount(
+  wallet: WalletSnapshot,
+): Promise<string> {
+  const pk = await loadOwnerPrivateKey();
+  if (!pk) throw new Error("Owner private key not found in SecureStore.");
+
+  const constructorCalldata = [wallet.ownerPublicKey, "0x0"];
+
+  const account = new Account({
+    provider: { nodeUrl: wallet.rpcUrl },
+    address: wallet.accountAddress,
+    signer: pk,
+  });
+
+  const deployResult = await account.deployAccount({
+    classHash: AGENT_ACCOUNT_CLASS_HASH,
+    constructorCalldata,
+    addressSalt: wallet.ownerPublicKey,
+  });
+
+  const txHash = deployResult.transaction_hash;
+  await saveDeployTxHash(txHash);
+
+  await appendActivity({
+    networkId: wallet.networkId,
+    kind: "deploy_account",
+    summary: `Deploy AgentAccount to ${wallet.accountAddress.slice(0, 10)}…`,
+    txHash,
+    status: "pending",
+  });
+
+  return txHash;
+}

--- a/apps/mobile/lib/wallet/use-deploy-status.ts
+++ b/apps/mobile/lib/wallet/use-deploy-status.ts
@@ -1,0 +1,100 @@
+/**
+ * useDeployStatus — tracks deploy lifecycle for the current wallet.
+ *
+ * States: loading → needs-funding → ready → deploying → deployed
+ */
+
+import * as React from "react";
+
+import { isContractDeployed } from "../starknet/rpc";
+import { checkDeployReadiness, deployAgentAccount } from "../starknet/deploy";
+import { loadDeployTxHash } from "./wallet";
+import type { WalletSnapshot } from "./wallet";
+
+export type DeployPhase = "loading" | "needs-funding" | "ready" | "deploying" | "deployed";
+
+type DeployStatusResult = {
+  phase: DeployPhase;
+  fundingMessage: string | null;
+  deployTxHash: string | null;
+  error: string | null;
+  checkFunding: () => void;
+  deploy: () => Promise<void>;
+};
+
+export function useDeployStatus(wallet: WalletSnapshot | null): DeployStatusResult {
+  const [phase, setPhase] = React.useState<DeployPhase>("loading");
+  const [fundingMessage, setFundingMessage] = React.useState<string | null>(null);
+  const [deployTxHash, setDeployTxHash] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [tick, setTick] = React.useState(0);
+
+  const checkFunding = React.useCallback(() => setTick((n) => n + 1), []);
+
+  // Initial check: is account already deployed? If not, check funding.
+  React.useEffect(() => {
+    if (!wallet) {
+      setPhase("loading");
+      return;
+    }
+
+    let cancelled = false;
+    setPhase("loading");
+    setError(null);
+
+    (async () => {
+      // First check if we have a saved deploy tx hash.
+      const savedTxHash = await loadDeployTxHash();
+      if (savedTxHash && !cancelled) {
+        setDeployTxHash(savedTxHash);
+      }
+
+      // Check if already deployed.
+      const deployed = await isContractDeployed(wallet.rpcUrl, wallet.accountAddress);
+      if (cancelled) return;
+
+      if (deployed) {
+        setPhase("deployed");
+        return;
+      }
+
+      // Check funding.
+      const result = await checkDeployReadiness(wallet);
+      if (cancelled) return;
+
+      if (result.canDeploy) {
+        setPhase("ready");
+        setFundingMessage(null);
+      } else {
+        setPhase("needs-funding");
+        setFundingMessage(result.reason);
+      }
+    })().catch((err) => {
+      if (cancelled) return;
+      setError(err instanceof Error ? err.message : "Failed to check deploy status.");
+      setPhase("needs-funding");
+    });
+
+    return () => { cancelled = true; };
+  }, [wallet, tick]);
+
+  const deploy = React.useCallback(async () => {
+    if (!wallet) return;
+    setPhase("deploying");
+    setError(null);
+
+    try {
+      const txHash = await deployAgentAccount(wallet);
+      setDeployTxHash(txHash);
+      // After deploy tx is sent, switch to deployed (optimistic).
+      // The tx-tracker will poll for finality.
+      setPhase("deployed");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Deploy failed.";
+      setError(msg);
+      setPhase("ready"); // Allow retry.
+    }
+  }, [wallet]);
+
+  return { phase, fundingMessage, deployTxHash, error, checkFunding, deploy };
+}

--- a/apps/mobile/lib/wallet/wallet-store.tsx
+++ b/apps/mobile/lib/wallet/wallet-store.tsx
@@ -1,0 +1,82 @@
+/**
+ * WalletProvider — React context for wallet lifecycle.
+ *
+ * On mount: attempts to load an existing wallet from SecureStore.
+ * Exposes create / reset / the current WalletSnapshot.
+ */
+
+import * as React from "react";
+
+import {
+  createWallet,
+  loadWallet,
+  resetWallet,
+  type WalletSnapshot,
+} from "./wallet";
+import type { StarknetNetworkId } from "../starknet/networks";
+
+type WalletStatus = "loading" | "none" | "ready";
+
+type WalletContextValue = {
+  status: WalletStatus;
+  wallet: WalletSnapshot | null;
+  create: (networkId?: StarknetNetworkId) => Promise<WalletSnapshot>;
+  reset: () => Promise<void>;
+};
+
+const WalletContext = React.createContext<WalletContextValue | null>(null);
+
+export function WalletProvider(props: { children: React.ReactNode }) {
+  const [status, setStatus] = React.useState<WalletStatus>("loading");
+  const [wallet, setWallet] = React.useState<WalletSnapshot | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const snap = await loadWallet();
+      if (cancelled) return;
+      if (snap) {
+        setWallet(snap);
+        setStatus("ready");
+      } else {
+        setStatus("none");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const create = React.useCallback(
+    async (networkId: StarknetNetworkId = "sepolia") => {
+      const snap = await createWallet(networkId);
+      setWallet(snap);
+      setStatus("ready");
+      return snap;
+    },
+    [],
+  );
+
+  const reset = React.useCallback(async () => {
+    await resetWallet();
+    setWallet(null);
+    setStatus("none");
+  }, []);
+
+  const value = React.useMemo<WalletContextValue>(
+    () => ({ status, wallet, create, reset }),
+    [status, wallet, create, reset],
+  );
+
+  return (
+    <WalletContext.Provider value={value}>
+      {props.children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet(): WalletContextValue {
+  const ctx = React.useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used within <WalletProvider />");
+  return ctx;
+}


### PR DESCRIPTION
## Summary

Closes #5.

### New modules

**`lib/starknet/deploy.ts`** — Deploy logic
- `checkDeployReadiness(wallet)`: verifies account isn't already deployed + has sufficient funds (≥0.001 ETH or ≥0.1 STRK)
- `deployAgentAccount(wallet)`: loads owner key from SecureStore, sends `deployAccount` via starknet.js, persists tx hash, appends activity entry

**`lib/wallet/use-deploy-status.ts`** — React hook for deploy lifecycle
- Phases: `loading` → `needs-funding` → `ready` → `deploying` → `deployed`
- Auto-checks on mount: is deployed? has funds?
- Exposes `checkFunding()` for manual recheck + `deploy()` to trigger
- Persists deploy tx hash across restarts via `saveDeployTxHash`

### Modified: Settings modal (`modal.tsx`)

When a wallet exists, shows an **"Agent account"** card with:
- Phase badge (Deployed/Deploying/Ready/Needs funding/Checking)
- Copyable account address + network
- Funding message + faucet instructions for Sepolia
- "Deploy account" button when ready
- Deploy tx hash display when available
- Error message with retry capability

### Checks

- `npm run typecheck` ✅
- `npm run lint` ✅

### Depends on

- #3 (wallet lifecycle) for `useWallet()`
- #2 (backend abstraction) for full mode-aware integration

🤖 agent-0708d554