### PR TITLE
feat(#7): agent transfer flow with on-chain denial UX

### DIFF
--- a/apps/mobile/lib/agent/transfer-errors.ts
+++ b/apps/mobile/lib/agent/transfer-errors.ts
@@ -1,0 +1,94 @@
+/**
+ * transfer-errors — maps common on-chain revert reasons to user guidance.
+ */
+
+type GuidanceEntry = {
+  pattern: RegExp;
+  title: string;
+  guidance: string;
+};
+
+const GUIDANCE_TABLE: GuidanceEntry[] = [
+  {
+    pattern: /spending.*limit|exceeds.*cap|cap.*exceeded/i,
+    title: "Spending cap exceeded",
+    guidance: "Reduce the amount or increase your session key spending limit in Policies.",
+  },
+  {
+    pattern: /session.*key.*expired|key.*validity/i,
+    title: "Session key expired",
+    guidance: "Create a new session key in Policies with a longer validity period.",
+  },
+  {
+    pattern: /session.*key.*not.*found|invalid.*session/i,
+    title: "Invalid session key",
+    guidance: "The session key is not registered on-chain. Register it in Policies.",
+  },
+  {
+    pattern: /insufficient.*balance|transfer.*amount.*exceeds/i,
+    title: "Insufficient balance",
+    guidance: "You don't have enough of this token. Reduce the amount.",
+  },
+  {
+    pattern: /lockdown|emergency.*revoke|all.*keys.*revoked/i,
+    title: "Emergency lockdown active",
+    guidance: "All session keys have been revoked. Disable lockdown and create new keys.",
+  },
+  {
+    pattern: /not.*allowed.*target|target.*not.*in.*allowlist/i,
+    title: "Target not allowed",
+    guidance: "The recipient or contract is not in the session key's allowed target list.",
+  },
+  {
+    pattern: /nonce/i,
+    title: "Nonce conflict",
+    guidance: "A concurrent transaction may be pending. Wait a moment and try again.",
+  },
+  {
+    pattern: /fee.*too.*low|insufficient.*fee/i,
+    title: "Gas fee too low",
+    guidance: "The network is congested. Try again in a moment.",
+  },
+];
+
+export type TransferGuidance = {
+  title: string;
+  guidance: string;
+  rawReason: string | null;
+};
+
+export function classifyRevertReason(
+  revertReason: string | null,
+  executionStatus: string | null,
+): TransferGuidance | null {
+  if (
+    !executionStatus ||
+    executionStatus.toUpperCase() === "SUCCEEDED"
+  ) {
+    return null;
+  }
+
+  if (!revertReason) {
+    return {
+      title: "Transaction reverted",
+      guidance: "The transaction was rejected on-chain. Check your policies and try again.",
+      rawReason: null,
+    };
+  }
+
+  for (const entry of GUIDANCE_TABLE) {
+    if (entry.pattern.test(revertReason)) {
+      return {
+        title: entry.title,
+        guidance: entry.guidance,
+        rawReason: revertReason,
+      };
+    }
+  }
+
+  return {
+    title: "Transaction reverted",
+    guidance: "The on-chain execution failed. Review your policies or try a smaller amount.",
+    rawReason: revertReason,
+  };
+}

--- a/apps/mobile/lib/agent/use-transfer.ts
+++ b/apps/mobile/lib/agent/use-transfer.ts
@@ -1,0 +1,101 @@
+/**
+ * useTransfer — React hook for the live transfer lifecycle.
+ *
+ * Phases: idle → preparing → preview → executing → done | denied
+ */
+
+import * as React from "react";
+
+import {
+  prepareTransferFromText,
+  executeTransfer,
+  type TransferAction,
+} from "./transfer";
+import {
+  classifyRevertReason,
+  type TransferGuidance,
+} from "./transfer-errors";
+import { appendActivity } from "../activity/activity";
+import type { WalletSnapshot } from "../wallet/wallet";
+
+export type TransferPhase = "idle" | "preparing" | "preview" | "executing" | "done" | "denied";
+
+type TransferResult = {
+  phase: TransferPhase;
+  action: TransferAction | null;
+  txHash: string | null;
+  guidance: TransferGuidance | null;
+  error: string | null;
+  prepare: (text: string) => Promise<void>;
+  execute: () => Promise<void>;
+  reset: () => void;
+};
+
+export function useTransfer(wallet: WalletSnapshot | null): TransferResult {
+  const [phase, setPhase] = React.useState<TransferPhase>("idle");
+  const [action, setAction] = React.useState<TransferAction | null>(null);
+  const [txHash, setTxHash] = React.useState<string | null>(null);
+  const [guidance, setGuidance] = React.useState<TransferGuidance | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const reset = React.useCallback(() => {
+    setPhase("idle");
+    setAction(null);
+    setTxHash(null);
+    setGuidance(null);
+    setError(null);
+  }, []);
+
+  const prepare = React.useCallback(
+    async (text: string) => {
+      if (!wallet) return;
+      setPhase("preparing");
+      setError(null);
+      setGuidance(null);
+
+      try {
+        const prepared = await prepareTransferFromText({ wallet, text });
+        setAction(prepared);
+        setPhase("preview");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to prepare transfer.");
+        setPhase("idle");
+      }
+    },
+    [wallet],
+  );
+
+  const execute = React.useCallback(async () => {
+    if (!wallet || !action) return;
+    setPhase("executing");
+    setError(null);
+
+    try {
+      const result = await executeTransfer({ wallet, action });
+      setTxHash(result.txHash);
+
+      await appendActivity({
+        networkId: wallet.networkId,
+        kind: "transfer",
+        summary: `Transfer ${action.amount} ${action.tokenSymbol} to ${action.to.slice(0, 10)}…`,
+        txHash: result.txHash,
+        status: result.executionStatus?.toUpperCase() === "REVERTED" ? "reverted" : "pending",
+        executionStatus: result.executionStatus,
+        revertReason: result.revertReason,
+      });
+
+      const g = classifyRevertReason(result.revertReason, result.executionStatus);
+      if (g) {
+        setGuidance(g);
+        setPhase("denied");
+      } else {
+        setPhase("done");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Transfer execution failed.");
+      setPhase("preview"); // Allow retry from preview.
+    }
+  }, [wallet, action]);
+
+  return { phase, action, txHash, guidance, error, prepare, execute, reset };
+}


### PR DESCRIPTION
## Summary

Closes #7.

### New modules

**`lib/agent/transfer-errors.ts`** — Revert reason classifier

Maps on-chain revert reasons to user-safe guidance:

| Pattern | Title | Guidance |
|---------|-------|----------|
| spending cap/limit | Spending cap exceeded | Reduce amount or increase cap |
| session key expired | Session key expired | Create new key with longer validity |
| invalid session | Invalid session key | Register key on-chain in Policies |
| insufficient balance | Insufficient balance | Reduce the amount |
| lockdown/emergency | Emergency lockdown active | Disable lockdown + create new keys |
| target not allowed | Target not allowed | Target not in allowlist |
| nonce | Nonce conflict | Wait and retry |
| fee too low | Gas fee too low | Retry later |

Falls back to generic "Transaction reverted" with raw reason for unrecognized errors.

**`lib/agent/use-transfer.ts`** — React hook for transfer lifecycle

- Phases: `idle` → `preparing` → `preview` → `executing` → `done` | `denied`
- `prepare(text)`: parses user input via existing `prepareTransferFromText`, shows warnings
- `execute()`: signs with session key via `executeTransfer`, appends activity entry
- On revert: surfaces `TransferGuidance` with title + actionable guidance + raw reason
- `reset()`: returns to idle for new transfer
- Error handling: prepare/execute failures show user-safe messages, allow retry

### Design decisions

- No UI changes in this PR — the hook and classifier are standalone modules that screens can import when wired. The Agent screen integration depends on #2 (backend abstraction) for mode awareness.
- Wraps existing `transfer.ts` functions rather than duplicating logic
- Activity entries track execution status and revert reason for the audit trail (#8)

### Checks

- `npm run typecheck` ✅
- `npm run lint` ✅

### Depends on

- #2 (backend abstraction) for mode-aware screen wiring
- #3 (wallet lifecycle) for `WalletSnapshot`
- #6 (session key policies) for key registration flow

🤖 agent-0708d554