### PR TITLE
feat(#6): session key policies — create/register/revoke/emergency

### DIFF
--- a/apps/mobile/lib/policy/session-key-actions.ts
+++ b/apps/mobile/lib/policy/session-key-actions.ts
@@ -1,0 +1,105 @@
+/**
+ * session-key-actions — owner-gated session key management.
+ *
+ * Wraps on-chain operations with biometric auth + activity logging.
+ */
+
+import { requireOwnerAuth } from "../security/owner-auth";
+import { appendActivity } from "../activity/activity";
+import { loadOwnerPrivateKey } from "../wallet/wallet";
+import type { WalletSnapshot } from "../wallet/wallet";
+import {
+  createLocalSessionKey,
+  registerSessionKeyOnchain,
+  revokeSessionKeyOnchain,
+  emergencyRevokeAllOnchain,
+  type StoredSessionKey,
+} from "./session-keys";
+
+export async function createAndRegisterSessionKey(params: {
+  wallet: WalletSnapshot;
+  tokenSymbol: string;
+  tokenAddress: string;
+  spendingLimit: bigint;
+  validForSeconds: number;
+  allowedContract: string;
+}): Promise<{ session: StoredSessionKey; txHash: string }> {
+  await requireOwnerAuth({ reason: "Create session key" });
+
+  const pk = await loadOwnerPrivateKey();
+  if (!pk) throw new Error("Owner private key not found.");
+
+  const session = await createLocalSessionKey({
+    tokenSymbol: params.tokenSymbol,
+    tokenAddress: params.tokenAddress,
+    spendingLimit: params.spendingLimit,
+    validForSeconds: params.validForSeconds,
+    allowedContract: params.allowedContract,
+  });
+
+  const { txHash } = await registerSessionKeyOnchain({
+    wallet: params.wallet,
+    ownerPrivateKey: pk,
+    session,
+  });
+
+  await appendActivity({
+    networkId: params.wallet.networkId,
+    kind: "register_session_key",
+    summary: `Register session key for ${params.tokenSymbol} (cap: ${params.spendingLimit.toString()})`,
+    txHash,
+    status: "pending",
+  });
+
+  return { session, txHash };
+}
+
+export async function revokeSessionKey(params: {
+  wallet: WalletSnapshot;
+  sessionPublicKey: string;
+}): Promise<{ txHash: string }> {
+  await requireOwnerAuth({ reason: "Revoke session key" });
+
+  const pk = await loadOwnerPrivateKey();
+  if (!pk) throw new Error("Owner private key not found.");
+
+  const { txHash } = await revokeSessionKeyOnchain({
+    wallet: params.wallet,
+    ownerPrivateKey: pk,
+    sessionPublicKey: params.sessionPublicKey,
+  });
+
+  await appendActivity({
+    networkId: params.wallet.networkId,
+    kind: "revoke_session_key",
+    summary: `Revoke session key ${params.sessionPublicKey.slice(0, 10)}…`,
+    txHash,
+    status: "pending",
+  });
+
+  return { txHash };
+}
+
+export async function emergencyRevokeAll(params: {
+  wallet: WalletSnapshot;
+}): Promise<{ txHash: string }> {
+  await requireOwnerAuth({ reason: "Emergency revoke all session keys" });
+
+  const pk = await loadOwnerPrivateKey();
+  if (!pk) throw new Error("Owner private key not found.");
+
+  const { txHash } = await emergencyRevokeAllOnchain({
+    wallet: params.wallet,
+    ownerPrivateKey: pk,
+  });
+
+  await appendActivity({
+    networkId: params.wallet.networkId,
+    kind: "emergency_revoke_all",
+    summary: "Emergency revoke all session keys",
+    txHash,
+    status: "pending",
+  });
+
+  return { txHash };
+}

--- a/apps/mobile/lib/policy/use-session-keys.ts
+++ b/apps/mobile/lib/policy/use-session-keys.ts
@@ -1,0 +1,201 @@
+/**
+ * use-session-keys — React hook for session key lifecycle management.
+ *
+ * Surfaces local session keys, on-chain validity, and mutation actions
+ * (create, revoke, emergency revoke-all). All mutations gate on owner auth
+ * via session-key-actions.ts.
+ */
+
+import * as React from "react";
+
+import type { WalletSnapshot } from "../wallet/wallet";
+import {
+  listSessionKeys,
+  isSessionKeyValidOnchain,
+  type StoredSessionKey,
+} from "./session-keys";
+import {
+  createAndRegisterSessionKey,
+  revokeSessionKey,
+  emergencyRevokeAll,
+} from "./session-key-actions";
+
+export type SessionKeyEntry = StoredSessionKey & {
+  /** On-chain validity (null = not yet checked). */
+  onchainValid: boolean | null;
+};
+
+export type SessionKeysStatus =
+  | "loading"
+  | "ready"
+  | "creating"
+  | "revoking"
+  | "emergency"
+  | "error";
+
+export type SessionKeysResult = {
+  status: SessionKeysStatus;
+  keys: SessionKeyEntry[];
+  error: string | null;
+
+  /** Reload the local key list + on-chain status. */
+  refresh: () => void;
+
+  /** Create a new session key and register it on-chain. */
+  create: (params: {
+    tokenSymbol: string;
+    tokenAddress: string;
+    spendingLimit: bigint;
+    validForSeconds: number;
+    allowedContract: string;
+  }) => Promise<{ txHash: string } | null>;
+
+  /** Revoke a single session key on-chain. */
+  revoke: (sessionPublicKey: string) => Promise<{ txHash: string } | null>;
+
+  /** Emergency revoke all session keys on-chain. */
+  revokeAll: () => Promise<{ txHash: string } | null>;
+};
+
+export function useSessionKeys(
+  wallet: WalletSnapshot | null,
+): SessionKeysResult {
+  const [status, setStatus] = React.useState<SessionKeysStatus>("loading");
+  const [keys, setKeys] = React.useState<SessionKeyEntry[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const loadRef = React.useRef(0);
+
+  const load = React.useCallback(async () => {
+    const id = ++loadRef.current;
+    try {
+      const local = await listSessionKeys();
+
+      const entries: SessionKeyEntry[] = local.map((k) => ({
+        ...k,
+        onchainValid: null,
+      }));
+
+      if (id !== loadRef.current) return;
+      setKeys(entries);
+      setStatus("ready");
+      setError(null);
+
+      // Check on-chain validity in background for non-revoked keys.
+      if (!wallet) return;
+
+      const active = entries.filter((k) => !k.revokedAt && k.registeredAt);
+      const results = await Promise.allSettled(
+        active.map((k) =>
+          isSessionKeyValidOnchain({
+            rpcUrl: wallet.rpcUrl,
+            accountAddress: wallet.accountAddress,
+            sessionPublicKey: k.key,
+          }),
+        ),
+      );
+
+      if (id !== loadRef.current) return;
+
+      setKeys((prev) => {
+        const updated = [...prev];
+        for (let i = 0; i < active.length; i++) {
+          const r = results[i];
+          const idx = updated.findIndex((k) => k.key === active[i].key);
+          if (idx >= 0 && r.status === "fulfilled") {
+            updated[idx] = { ...updated[idx], onchainValid: r.value };
+          }
+        }
+        return updated;
+      });
+    } catch (e) {
+      if (id !== loadRef.current) return;
+      setError(e instanceof Error ? e.message : "Failed to load session keys");
+      setStatus("error");
+    }
+  }, [wallet]);
+
+  React.useEffect(() => {
+    load();
+  }, [load]);
+
+  const create = React.useCallback(
+    async (params: {
+      tokenSymbol: string;
+      tokenAddress: string;
+      spendingLimit: bigint;
+      validForSeconds: number;
+      allowedContract: string;
+    }): Promise<{ txHash: string } | null> => {
+      if (!wallet) return null;
+      setStatus("creating");
+      setError(null);
+      try {
+        const { txHash } = await createAndRegisterSessionKey({
+          wallet,
+          ...params,
+        });
+        await load();
+        return { txHash };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Create failed";
+        setError(msg);
+        setStatus("error");
+        return null;
+      }
+    },
+    [wallet, load],
+  );
+
+  const revoke = React.useCallback(
+    async (
+      sessionPublicKey: string,
+    ): Promise<{ txHash: string } | null> => {
+      if (!wallet) return null;
+      setStatus("revoking");
+      setError(null);
+      try {
+        const { txHash } = await revokeSessionKey({
+          wallet,
+          sessionPublicKey,
+        });
+        await load();
+        return { txHash };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Revoke failed";
+        setError(msg);
+        setStatus("error");
+        return null;
+      }
+    },
+    [wallet, load],
+  );
+
+  const revokeAllFn = React.useCallback(async (): Promise<{
+    txHash: string;
+  } | null> => {
+    if (!wallet) return null;
+    setStatus("emergency");
+    setError(null);
+    try {
+      const { txHash } = await emergencyRevokeAll({ wallet });
+      await load();
+      return { txHash };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Emergency revoke failed";
+      setError(msg);
+      setStatus("error");
+      return null;
+    }
+  }, [wallet, load]);
+
+  return {
+    status,
+    keys,
+    error,
+    refresh: load,
+    create,
+    revoke,
+    revokeAll: revokeAllFn,
+  };
+}


### PR DESCRIPTION
## Summary
- **`lib/policy/session-key-actions.ts`** — Owner-gated wrappers for session key mutations. Every action (create+register, revoke, emergency revoke-all) requires biometric auth via `requireOwnerAuth` and logs to the activity timeline.
- **`lib/policy/use-session-keys.ts`** — React hook (`useSessionKeys`) that manages the full lifecycle: loads local keys, checks on-chain validity in background, and exposes `create`, `revoke`, `revokeAll` actions with loading/error state.

## Acceptance Criteria
- [x] User can create a local session key and register it on-chain (via `createAndRegisterSessionKey`)
- [x] Revocation and emergency revoke-all work and are reflected in hook state
- [x] Owner auth is required for all policy mutations (`requireOwnerAuth`)
- [x] `./scripts/app/check` passes

Closes #6

🤖 agent-0708d554