### PR TITLE
feat(#16): AVNU swap with bounded approvals + policy enforcement

### DIFF
--- a/apps/mobile/lib/activity/activity.ts
+++ b/apps/mobile/lib/activity/activity.ts
@@ -13,7 +13,8 @@ export type ActivityItem = {
     | "register_session_key"
     | "revoke_session_key"
     | "emergency_revoke_all"
-    | "transfer";
+    | "transfer"
+    | "swap";
   summary: string;
   txHash?: string;
   status: ActivityStatus;

--- a/apps/mobile/lib/defi/avnu/client.ts
+++ b/apps/mobile/lib/defi/avnu/client.ts
@@ -1,0 +1,167 @@
+/**
+ * AVNU quote client — safe networking with endpoint allowlist,
+ * timeouts, and short-TTL caching.
+ */
+
+import type {
+  AvnuQuoteRequest,
+  AvnuQuoteResponse,
+  AvnuBuildSwapRequest,
+  AvnuBuildSwapResponse,
+} from "./types";
+
+// ── Endpoint allowlist ──────────────────────────────────────────────
+
+const ALLOWED_ENDPOINTS: Record<string, string> = {
+  mainnet: "https://starknet.api.avnu.fi",
+  sepolia: "https://sepolia.api.avnu.fi",
+};
+
+export type AvnuNetwork = keyof typeof ALLOWED_ENDPOINTS;
+
+function baseUrl(network: AvnuNetwork): string {
+  const url = ALLOWED_ENDPOINTS[network];
+  if (!url) throw new Error(`Unknown AVNU network: ${network}`);
+  return url;
+}
+
+// ── Fetch with timeout ──────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+// ── Cache ───────────────────────────────────────────────────────────
+
+type CacheEntry<T> = { data: T; expiresAt: number };
+const cache = new Map<string, CacheEntry<unknown>>();
+const CACHE_TTL_MS = 15_000; // 15 seconds
+
+function cacheGet<T>(key: string): T | null {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.data as T;
+}
+
+function cacheSet<T>(key: string, data: T): void {
+  cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// ── Error classification ────────────────────────────────────────────
+
+export class AvnuClientError extends Error {
+  readonly statusCode?: number;
+
+  constructor(message: string, statusCode?: number) {
+    super(message);
+    this.name = "AvnuClientError";
+    this.statusCode = statusCode;
+  }
+}
+
+function classifyError(err: unknown): never {
+  if (err instanceof AvnuClientError) throw err;
+  if (err instanceof TypeError && err.message.includes("abort")) {
+    throw new AvnuClientError("AVNU request timed out.");
+  }
+  if (err instanceof DOMException && err.name === "AbortError") {
+    throw new AvnuClientError("AVNU request timed out.");
+  }
+  if (err instanceof TypeError) {
+    throw new AvnuClientError("Network error contacting AVNU.");
+  }
+  throw new AvnuClientError("AVNU request failed.");
+}
+
+// ── Quote fetch ─────────────────────────────────────────────────────
+
+function quoteCacheKey(network: AvnuNetwork, req: AvnuQuoteRequest): string {
+  return `avnu:quote:${network}:${req.sellTokenAddress}:${req.buyTokenAddress}:${req.sellAmount}`;
+}
+
+export async function fetchQuote(
+  network: AvnuNetwork,
+  req: AvnuQuoteRequest,
+): Promise<AvnuQuoteResponse> {
+  const key = quoteCacheKey(network, req);
+  const cached = cacheGet<AvnuQuoteResponse>(key);
+  if (cached) return cached;
+
+  const url = `${baseUrl(network)}/swap/v2/quotes`;
+  const params = new URLSearchParams({
+    sellTokenAddress: req.sellTokenAddress,
+    buyTokenAddress: req.buyTokenAddress,
+    sellAmount: req.sellAmount,
+  });
+  if (req.takerAddress) params.set("takerAddress", req.takerAddress);
+  if (req.size != null) params.set("size", String(req.size));
+  if (req.excludeSources?.length) params.set("excludeSources", req.excludeSources.join(","));
+
+  try {
+    const res = await fetchWithTimeout(`${url}?${params.toString()}`, {
+      method: "GET",
+      headers: { accept: "application/json" },
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      if (res.status === 429) throw new AvnuClientError("Rate limited by AVNU. Try again in a moment.", 429);
+      if (res.status >= 500) throw new AvnuClientError("AVNU server error. Try again later.", res.status);
+      throw new AvnuClientError(`AVNU error: ${text || res.statusText}`, res.status);
+    }
+
+    const data = (await res.json()) as AvnuQuoteResponse;
+    cacheSet(key, data);
+    return data;
+  } catch (err) {
+    classifyError(err);
+  }
+}
+
+// ── Build swap calldata (quote → calldata, no execution) ────────────
+
+export async function buildSwapCalldata(
+  network: AvnuNetwork,
+  req: AvnuBuildSwapRequest,
+): Promise<AvnuBuildSwapResponse> {
+  const url = `${baseUrl(network)}/swap/v2/build`;
+
+  try {
+    const res = await fetchWithTimeout(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify(req),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      if (res.status === 429) throw new AvnuClientError("Rate limited by AVNU. Try again in a moment.", 429);
+      if (res.status >= 500) throw new AvnuClientError("AVNU server error. Try again later.", res.status);
+      throw new AvnuClientError(`AVNU build error: ${text || res.statusText}`, res.status);
+    }
+
+    return (await res.json()) as AvnuBuildSwapResponse;
+  } catch (err) {
+    classifyError(err);
+  }
+}
+
+export function clearCache(): void {
+  cache.clear();
+}

--- a/apps/mobile/lib/defi/avnu/index.ts
+++ b/apps/mobile/lib/defi/avnu/index.ts
@@ -1,0 +1,16 @@
+export type {
+  AvnuQuoteRequest,
+  AvnuQuoteResponse,
+  AvnuQuote,
+  AvnuRoute,
+  AvnuBuildSwapRequest,
+  AvnuBuildSwapResponse,
+} from "./types";
+
+export {
+  fetchQuote,
+  buildSwapCalldata,
+  clearCache,
+  AvnuClientError,
+  type AvnuNetwork,
+} from "./client";

--- a/apps/mobile/lib/defi/avnu/types.ts
+++ b/apps/mobile/lib/defi/avnu/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Typed request/response models for the AVNU quote API.
+ */
+
+export type AvnuQuoteRequest = {
+  sellTokenAddress: string;
+  buyTokenAddress: string;
+  sellAmount: string; // hex or decimal string
+  takerAddress?: string;
+  size?: number;
+  excludeSources?: string[];
+};
+
+export type AvnuRoute = {
+  name: string;
+  address: string;
+  percent: number;
+};
+
+export type AvnuQuote = {
+  quoteId: string;
+  sellTokenAddress: string;
+  sellAmount: string;
+  sellAmountInUsd: number;
+  buyTokenAddress: string;
+  buyAmount: string;
+  buyAmountInUsd: number;
+  buyAmountWithoutFees: string;
+  buyAmountWithoutFeesInUsd: number;
+  gasFees: string;
+  gasFeesInUsd: number;
+  avnuFees: string;
+  avnuFeesInUsd: number;
+  priceRatioUsd: number;
+  routes: AvnuRoute[];
+  liquiditySource: string;
+  estimatedAmount: boolean;
+  expiry: number | null;
+};
+
+export type AvnuQuoteResponse = AvnuQuote[];
+
+export type AvnuBuildSwapRequest = {
+  quoteId: string;
+  takerAddress: string;
+  slippage: number; // e.g. 0.01 for 1%
+};
+
+export type AvnuBuildSwapResponse = {
+  calldata: string[];
+  contractAddress: string;
+  entrypoint: string;
+};

--- a/apps/mobile/lib/defi/swap.ts
+++ b/apps/mobile/lib/defi/swap.ts
@@ -1,0 +1,186 @@
+/**
+ * swap — bounded-approval swap flow via AVNU.
+ *
+ * Key safety invariant: ERC-20 approvals are always bounded to the exact
+ * sellAmount. Never issues unlimited approvals.
+ */
+
+import { hash } from "starknet";
+
+import { createOwnerAccount } from "../starknet/account";
+import { u256FromBigInt } from "../starknet/u256";
+import { formatUnits } from "../starknet/balances";
+import { appendActivity } from "../activity/activity";
+import { requireOwnerAuth } from "../security/owner-auth";
+import { loadOwnerPrivateKey } from "../wallet/wallet";
+import type { WalletSnapshot } from "../wallet/wallet";
+import type { StarknetToken } from "../starknet/tokens";
+
+import {
+  fetchQuote,
+  buildSwapCalldata,
+  type AvnuNetwork,
+  type AvnuQuote,
+} from "./avnu";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export type SwapPreview = {
+  quote: AvnuQuote;
+  sellToken: StarknetToken;
+  buyToken: StarknetToken;
+  sellAmountRaw: bigint;
+  sellAmountFormatted: string;
+  buyAmountFormatted: string;
+  minReceivedFormatted: string;
+  slippagePct: number;
+  gasFeeFormatted: string;
+  avnuFeeFormatted: string;
+  priceImpactPct: number;
+  routeSummary: string;
+};
+
+export type SwapResult = {
+  txHash: string;
+  sellSymbol: string;
+  buySymbol: string;
+  sellAmountFormatted: string;
+  buyAmountFormatted: string;
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function avnuNetwork(networkId: string): AvnuNetwork {
+  if (networkId === "mainnet") return "mainnet";
+  return "sepolia";
+}
+
+function parseHexOrDecimal(s: string): bigint {
+  if (s.startsWith("0x") || s.startsWith("0X")) return BigInt(s);
+  return BigInt(s);
+}
+
+// ── Prepare swap (quote + preview) ──────────────────────────────────
+
+const DEFAULT_SLIPPAGE = 0.01; // 1%
+
+export async function prepareSwap(params: {
+  wallet: WalletSnapshot;
+  sellToken: StarknetToken;
+  buyToken: StarknetToken;
+  sellAmount: bigint;
+  slippage?: number;
+}): Promise<SwapPreview> {
+  const network = avnuNetwork(params.wallet.networkId);
+  const slippage = params.slippage ?? DEFAULT_SLIPPAGE;
+
+  const sellAddress = params.sellToken.addressByNetwork[params.wallet.networkId];
+  const buyAddress = params.buyToken.addressByNetwork[params.wallet.networkId];
+
+  if (!sellAddress || !buyAddress) {
+    throw new Error("Token not available on this network.");
+  }
+
+  const sellAmountHex = `0x${params.sellAmount.toString(16)}`;
+
+  const quotes = await fetchQuote(network, {
+    sellTokenAddress: sellAddress,
+    buyTokenAddress: buyAddress,
+    sellAmount: sellAmountHex,
+    takerAddress: params.wallet.accountAddress,
+    size: 1,
+  });
+
+  if (!quotes.length) {
+    throw new Error("No swap route found for this pair.");
+  }
+
+  const quote = quotes[0];
+  const buyAmountRaw = parseHexOrDecimal(quote.buyAmount);
+  const minReceived = buyAmountRaw - (buyAmountRaw * BigInt(Math.floor(slippage * 10000))) / 10000n;
+
+  const routeNames = quote.routes.map((r) => r.name).join(" → ");
+
+  const priceImpactPct =
+    quote.buyAmountWithoutFeesInUsd > 0
+      ? ((quote.buyAmountWithoutFeesInUsd - quote.buyAmountInUsd) / quote.buyAmountWithoutFeesInUsd) * 100
+      : 0;
+
+  return {
+    quote,
+    sellToken: params.sellToken,
+    buyToken: params.buyToken,
+    sellAmountRaw: params.sellAmount,
+    sellAmountFormatted: formatUnits(params.sellAmount, params.sellToken.decimals),
+    buyAmountFormatted: formatUnits(buyAmountRaw, params.buyToken.decimals),
+    minReceivedFormatted: formatUnits(minReceived, params.buyToken.decimals),
+    slippagePct: slippage * 100,
+    gasFeeFormatted: `$${quote.gasFeesInUsd.toFixed(4)}`,
+    avnuFeeFormatted: `$${quote.avnuFeesInUsd.toFixed(4)}`,
+    priceImpactPct: Math.abs(priceImpactPct),
+    routeSummary: routeNames || quote.liquiditySource,
+  };
+}
+
+// ── Execute swap (bounded approve + swap call) ──────────────────────
+
+export async function executeSwap(params: {
+  wallet: WalletSnapshot;
+  preview: SwapPreview;
+}): Promise<SwapResult> {
+  await requireOwnerAuth({ reason: "Execute swap" });
+
+  const pk = await loadOwnerPrivateKey();
+  if (!pk) throw new Error("Owner private key not found.");
+
+  const network = avnuNetwork(params.wallet.networkId);
+  const sellAddress = params.preview.sellToken.addressByNetwork[params.wallet.networkId];
+
+  // Build swap calldata from AVNU.
+  const swap = await buildSwapCalldata(network, {
+    quoteId: params.preview.quote.quoteId,
+    takerAddress: params.wallet.accountAddress,
+    slippage: params.preview.slippagePct / 100,
+  });
+
+  // Bounded approval: approve exactly the sell amount, never unlimited.
+  const { low, high } = u256FromBigInt(params.preview.sellAmountRaw);
+  const approveSelector = hash.getSelectorFromName("approve");
+
+  const account = createOwnerAccount({
+    rpcUrl: params.wallet.rpcUrl,
+    accountAddress: params.wallet.accountAddress,
+    ownerPrivateKey: pk,
+  });
+
+  const tx = await account.execute([
+    // 1. Bounded ERC-20 approval (exact amount).
+    {
+      contractAddress: sellAddress,
+      entrypoint: "approve",
+      calldata: [swap.contractAddress, low, high],
+    },
+    // 2. Execute the swap via AVNU router.
+    {
+      contractAddress: swap.contractAddress,
+      entrypoint: swap.entrypoint,
+      calldata: swap.calldata,
+    },
+  ]);
+
+  await appendActivity({
+    networkId: params.wallet.networkId,
+    kind: "swap",
+    summary: `Swap ${params.preview.sellAmountFormatted} ${params.preview.sellToken.symbol} → ${params.preview.buyAmountFormatted} ${params.preview.buyToken.symbol}`,
+    txHash: tx.transaction_hash,
+    status: "pending",
+  });
+
+  return {
+    txHash: tx.transaction_hash,
+    sellSymbol: params.preview.sellToken.symbol,
+    buySymbol: params.preview.buyToken.symbol,
+    sellAmountFormatted: params.preview.sellAmountFormatted,
+    buyAmountFormatted: params.preview.buyAmountFormatted,
+  };
+}

--- a/apps/mobile/lib/defi/use-swap.ts
+++ b/apps/mobile/lib/defi/use-swap.ts
@@ -1,0 +1,94 @@
+/**
+ * use-swap — React hook for the AVNU swap lifecycle.
+ *
+ * Phases: idle → quoting → preview → executing → done | error
+ */
+
+import * as React from "react";
+
+import type { WalletSnapshot } from "../wallet/wallet";
+import type { StarknetToken } from "../starknet/tokens";
+
+import { prepareSwap, executeSwap, type SwapPreview, type SwapResult } from "./swap";
+
+export type SwapPhase = "idle" | "quoting" | "preview" | "executing" | "done" | "error";
+
+export type UseSwapResult = {
+  phase: SwapPhase;
+  preview: SwapPreview | null;
+  result: SwapResult | null;
+  error: string | null;
+
+  /** Fetch a quote and compute the swap preview. */
+  quote: (params: {
+    sellToken: StarknetToken;
+    buyToken: StarknetToken;
+    sellAmount: bigint;
+    slippage?: number;
+  }) => Promise<void>;
+
+  /** Confirm and execute the current preview. */
+  confirm: () => Promise<void>;
+
+  /** Reset back to idle. */
+  reset: () => void;
+};
+
+export function useSwap(wallet: WalletSnapshot | null): UseSwapResult {
+  const [phase, setPhase] = React.useState<SwapPhase>("idle");
+  const [preview, setPreview] = React.useState<SwapPreview | null>(null);
+  const [result, setResult] = React.useState<SwapResult | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const reset = React.useCallback(() => {
+    setPhase("idle");
+    setPreview(null);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const quote = React.useCallback(
+    async (params: {
+      sellToken: StarknetToken;
+      buyToken: StarknetToken;
+      sellAmount: bigint;
+      slippage?: number;
+    }) => {
+      if (!wallet) return;
+      setPhase("quoting");
+      setError(null);
+      setResult(null);
+      try {
+        const p = await prepareSwap({
+          wallet,
+          sellToken: params.sellToken,
+          buyToken: params.buyToken,
+          sellAmount: params.sellAmount,
+          slippage: params.slippage,
+        });
+        setPreview(p);
+        setPhase("preview");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Quote failed");
+        setPhase("error");
+      }
+    },
+    [wallet],
+  );
+
+  const confirm = React.useCallback(async () => {
+    if (!wallet || !preview) return;
+    setPhase("executing");
+    setError(null);
+    try {
+      const r = await executeSwap({ wallet, preview });
+      setResult(r);
+      setPhase("done");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Swap execution failed");
+      setPhase("error");
+    }
+  }, [wallet, preview]);
+
+  return { phase, preview, result, error, quote, confirm, reset };
+}


### PR DESCRIPTION
## Summary
- **`lib/defi/avnu/`** — AVNU quote client (identical to #41, will auto-merge) with endpoint allowlist, timeouts, caching.
- **`lib/defi/swap.ts`** — Core swap flow: `prepareSwap()` fetches AVNU quote and builds a deterministic preview (min received, slippage, fees, route, price impact). `executeSwap()` issues a **bounded ERC-20 approval** (exact sell amount, never unlimited) then executes the AVNU router call. Owner auth gated.
- **`lib/defi/use-swap.ts`** — React hook (`useSwap`) with phases: idle → quoting → preview → executing → done | error.
- **`lib/activity/activity.ts`** — Added `"swap"` to the `kind` union type.

## Acceptance Criteria
- [x] Approvals are bounded (never unlimited) — exact sell amount only
- [x] Swap executes on Sepolia via AVNU with owner auth enforcement
- [x] `./scripts/app/check` passes

Closes #16

🤖 agent-0708d554