### PR TITLE
security(#54): enforce runtime requester source + deterministic signer error tests

### DIFF
--- a/apps/mobile/lib/agent-runtime/tools/core-tools.ts
+++ b/apps/mobile/lib/agent-runtime/tools/core-tools.ts
@@ -276,7 +276,6 @@ export const executeTransferTool: ToolDefinition = {
         execution = await executeTransfer({
           wallet,
           action,
-          requester: "starkclaw-mobile",
           tool: "execute_transfer",
           mobileActionId,
         });


### PR DESCRIPTION
## Summary
- remove hardcoded `requester` override in `execute_transfer` tool wiring
- ensure requester label is sourced from signer runtime config (env/secure profile), not tool-level constant
- add runtime tests covering deterministic propagation of signer hard-failure messages (replay/auth/policy) and correlation persistence on failures

## Threat model
The tool layer should not downgrade signer identity metadata by overriding requester labels. A hardcoded requester weakens operational attribution and can mask environment-specific identity labels in production.

## Security impact
- keeps remote signer metadata provenance in one place (`runtime-config`)
- improves deterministic UX for signer failure classes and preserves audit trail data (`mobileActionId`, `signerRequestId` null on failed sign path)

## Tests
- `npm --prefix starkclaw-54-runtime/apps/mobile test -- --run lib/agent-runtime/tools/__tests__/core-tools.runtime.test.ts`
- `npm --prefix starkclaw-54-runtime/apps/mobile test -- --run lib/signer/__tests__/runtime-config.test.ts lib/signer/__tests__/keyring-proxy-signer.test.ts lib/agent-runtime/tools/__tests__/core-tools.runtime.test.ts`
- `cd starkclaw-54-runtime && ./scripts/check`

## Rollback
Revert this PR commit to restore prior behavior (hardcoded requester + previous test coverage).
