### PR TITLE
feat(#72): migrate session key calls to session-account API

### DIFF
--- a/apps/mobile/lib/policy/__tests__/session-keys.migration.test.ts
+++ b/apps/mobile/lib/policy/__tests__/session-keys.migration.test.ts
@@ -102,8 +102,8 @@ describe("session-keys migration", () => {
     expect(calls[0].calldata[0]).toBe(session.key);
     expect(calls[0].calldata[1]).toBe(session.validUntil.toString());
     expect(calls[0].calldata[2]).toBe("100");
-    expect(calls[0].calldata[3]).toBe("4");
-    expect(calls[0].calldata.slice(4)).toHaveLength(4);
+    expect(calls[0].calldata[3]).toBe("1");
+    expect(calls[0].calldata.slice(4)).toHaveLength(1);
     for (const selector of calls[0].calldata.slice(4)) {
       expect(selector).toMatch(/^0x[0-9a-f]+$/);
     }

--- a/apps/mobile/lib/policy/session-keys.ts
+++ b/apps/mobile/lib/policy/session-keys.ts
@@ -12,9 +12,6 @@ const DEFAULT_SESSION_MAX_CALLS = 100;
 const DEFAULT_SPENDING_WINDOW_SECONDS = 86_400;
 const DEFAULT_ALLOWED_ENTRYPOINTS = [
   hash.getSelectorFromName("transfer"),
-  hash.getSelectorFromName("approve"),
-  hash.getSelectorFromName("increase_allowance"),
-  hash.getSelectorFromName("increaseAllowance"),
 ];
 
 function sessionPkStorageKey(sessionPublicKey: string): string {
@@ -124,7 +121,8 @@ export async function registerSessionKeyOnchain(params: {
   });
 
   // SessionAccount scopes sessions by entrypoint selectors (not contract address).
-  // Keep default selectors tight and rely on per-token spending policy for amount bounds.
+  // Keep default selectors minimal (`transfer` only) and rely on per-token
+  // spending policy for amount bounds.
   const tx = await account.execute([
     {
       contractAddress: params.wallet.accountAddress,


### PR DESCRIPTION
## Summary
Closes #72.

Migrates Starkclaw session-key onchain calls from legacy `agent-account` API to canonical `session-account` API.

### Runtime changes
- `registerSessionKeyOnchain` now sends a batched owner tx:
  1. `add_or_update_session_key(session_key, valid_until, max_calls, allowed_entrypoints[])`
  2. `set_spending_policy(session_key, token, max_per_call, max_per_window, window_seconds)`
- `isSessionKeyValidOnchain` now uses `get_session_data` and derives validity from:
  - `valid_until > now`
  - `calls_used < max_calls`
- Keeps a tight default selector list and relies on per-token spending policy for amount bounds.

### Test coverage (TDD)
Added `apps/mobile/lib/policy/__tests__/session-keys.migration.test.ts`:
- verifies calldata shape for both migrated entrypoints
- verifies spending policy calldata (`u256 low/high`, 24h window)
- verifies session validity derivation from `get_session_data`
- verifies fail-closed behavior on RPC errors

## Security notes
- removes dependency on legacy `register_session_key` entrypoint
- fail-closed validity check (`false` on RPC failures)
- keeps permissions explicit via entrypoint selector allowlist

## Validation run
- `pnpm test lib/policy/__tests__/session-keys.migration.test.ts --run`
- `pnpm test --run` (apps/mobile)
- `pnpm typecheck` (apps/mobile)

## Out of scope
- cert pinning (`#67`)
- full legacy contract retirement (`#73`)
