### PR TITLE
security(#67): implement SSL public-key pinning for remote signer

### DIFF
--- a/apps/mobile/lib/signer/README.md
+++ b/apps/mobile/lib/signer/README.md
@@ -12,6 +12,7 @@ This folder now has two layers:
 - `client.ts`: generic typed HTTP client + error mapping (groundwork).
 - `keyring-proxy-signer.ts`: Starknet `SignerInterface` implementation that signs through SISNA keyring proxy with HMAC headers.
 - `runtime-config.ts`: remote/local mode config loader with production transport guards.
+- `pinning.ts`: SSL public-key pinning initializer (fail-closed in production remote mode).
 
 Execution wiring uses `keyring-proxy-signer.ts` in remote mode.
 
@@ -63,8 +64,16 @@ Remote signer mode now enforces stricter production constraints in `runtime-conf
 - Loopback signer endpoints (`localhost`, `127.0.0.1`, `::1`) are rejected in production.
 - `EXPO_PUBLIC_SISNA_MTLS_REQUIRED` must be truthy in production.
 - `EXPO_PUBLIC_SISNA_REQUESTER` must be explicitly set in production (no default fallback).
+- `EXPO_PUBLIC_SISNA_PINNED_PUBKEYS` must include at least two base64 sha256(SPKI) hashes in production.
+- Optional: `EXPO_PUBLIC_SISNA_PIN_INCLUDE_SUBDOMAINS=true` and `EXPO_PUBLIC_SISNA_PIN_EXPIRATION_DATE=yyyy-MM-dd`.
 
 This prevents ambiguous deployment posture where app traffic appears "production" but is still using local/dev transport assumptions.
+
+## Certificate Pinning Notes
+
+- Pinning runtime uses `react-native-ssl-public-key-pinning` and is initialized before remote signing.
+- If pinning cannot initialize in remote mode, transfer execution fails closed before signing.
+- Expo Go does not provide the native module; use a development/production build for remote signer testing.
 
 ## Legacy Groundwork Usage
 

--- a/apps/mobile/lib/signer/__tests__/pinning.test.ts
+++ b/apps/mobile/lib/signer/__tests__/pinning.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/storage/secure-store", () => ({
+  secureGet: vi.fn(async () => null),
+  secureSet: vi.fn(async () => {}),
+  secureDelete: vi.fn(async () => {}),
+}));
+
+const hoisted = vi.hoisted(() => {
+  const initializeSslPinning = vi.fn(async () => {});
+  const isSslPinningAvailable = vi.fn(() => true);
+  return {
+    initializeSslPinning,
+    isSslPinningAvailable,
+    loader: vi.fn(async () => ({
+      initializeSslPinning,
+      isSslPinningAvailable,
+    })),
+  };
+});
+
+import {
+  ensureSignerCertificatePinning,
+  setPinningModuleLoaderForTests,
+  resetSignerCertificatePinningForTests,
+} from "../pinning";
+
+describe("signer certificate pinning", () => {
+  const baseConfig = {
+    proxyUrl: "https://signer.internal:8545",
+    pinnedPublicKeyHashes: [
+      "CLOmM1/OXvSPjw5UOYbAf9GKOxImEp9hhku9W90fHMk=",
+      "hxqRlPTu1bMS/0DITB1SSu0vd4u/8l8TjPgfaAp63Gc=",
+    ],
+    pinningIncludeSubdomains: false,
+    pinningExpirationDate: undefined,
+  };
+
+  beforeEach(() => {
+    resetSignerCertificatePinningForTests();
+    setPinningModuleLoaderForTests(hoisted.loader);
+    hoisted.loader.mockReset();
+    hoisted.loader.mockResolvedValue({
+      initializeSslPinning: hoisted.initializeSslPinning,
+      isSslPinningAvailable: hoisted.isSslPinningAvailable,
+    });
+    hoisted.initializeSslPinning.mockReset();
+    hoisted.initializeSslPinning.mockResolvedValue(undefined);
+    hoisted.isSslPinningAvailable.mockReset();
+    hoisted.isSslPinningAvailable.mockReturnValue(true);
+  });
+
+  it("initializes pinning for signer hostname with configured hashes", async () => {
+    await ensureSignerCertificatePinning(baseConfig);
+
+    expect(hoisted.initializeSslPinning).toHaveBeenCalledTimes(1);
+    expect(hoisted.initializeSslPinning).toHaveBeenCalledWith({
+      "signer.internal": {
+        includeSubdomains: false,
+        publicKeyHashes: baseConfig.pinnedPublicKeyHashes,
+        expirationDate: undefined,
+      },
+    });
+  });
+
+  it("avoids duplicate pinning initialization for same config", async () => {
+    await ensureSignerCertificatePinning(baseConfig);
+    await ensureSignerCertificatePinning(baseConfig);
+
+    expect(hoisted.initializeSslPinning).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when pinning module is unavailable", async () => {
+    hoisted.isSslPinningAvailable.mockReturnValue(false);
+
+    await expect(ensureSignerCertificatePinning(baseConfig)).rejects.toMatchObject({
+      code: "PINNING_UNAVAILABLE",
+    });
+  });
+
+  it("surfaces deterministic error when pinning initialization fails", async () => {
+    hoisted.initializeSslPinning.mockRejectedValue(new Error("bad pins"));
+
+    await expect(ensureSignerCertificatePinning(baseConfig)).rejects.toMatchObject({
+      code: "PINNING_INIT_FAILED",
+    });
+  });
+
+  it("surfaces deterministic error when pinning module cannot be loaded", async () => {
+    hoisted.loader.mockRejectedValue(new Error("module missing"));
+
+    await expect(ensureSignerCertificatePinning(baseConfig)).rejects.toMatchObject({
+      code: "PINNING_UNAVAILABLE",
+    });
+  });
+});

--- a/apps/mobile/lib/signer/pinning.ts
+++ b/apps/mobile/lib/signer/pinning.ts
@@ -1,0 +1,86 @@
+import { SignerRuntimeConfigError } from "./runtime-config";
+
+type CertificatePinningConfig = {
+  proxyUrl: string;
+  pinnedPublicKeyHashes: string[];
+  pinningIncludeSubdomains: boolean;
+  pinningExpirationDate?: string;
+};
+
+type PinningModule = {
+  isSslPinningAvailable?: () => boolean;
+  initializeSslPinning: (options: Record<string, unknown>) => Promise<void>;
+};
+
+let lastInitializedConfigFingerprint: string | null = null;
+let pinningModuleLoader: (() => Promise<PinningModule>) | null = null;
+
+function buildConfigFingerprint(config: CertificatePinningConfig): string {
+  return JSON.stringify({
+    proxyUrl: config.proxyUrl,
+    pinnedPublicKeyHashes: [...config.pinnedPublicKeyHashes].sort(),
+    pinningIncludeSubdomains: config.pinningIncludeSubdomains,
+    pinningExpirationDate: config.pinningExpirationDate ?? null,
+  });
+}
+
+async function loadPinningModule(): Promise<PinningModule> {
+  try {
+    if (pinningModuleLoader) {
+      return await pinningModuleLoader();
+    }
+    const moduleName = "react-native-ssl-public-key-pinning";
+    const module = await import(/* @vite-ignore */ moduleName);
+    return module as unknown as PinningModule;
+  } catch {
+    throw new SignerRuntimeConfigError(
+      "PINNING_UNAVAILABLE",
+      "SSL pinning module is unavailable. Build with native pinning support enabled."
+    );
+  }
+}
+
+export async function ensureSignerCertificatePinning(
+  config: CertificatePinningConfig
+): Promise<void> {
+  if (config.pinnedPublicKeyHashes.length === 0) return;
+
+  const fingerprint = buildConfigFingerprint(config);
+  if (lastInitializedConfigFingerprint === fingerprint) return;
+
+  const hostname = new URL(config.proxyUrl).hostname;
+  const pinning = await loadPinningModule();
+  const available = pinning.isSslPinningAvailable?.();
+  if (available === false) {
+    throw new SignerRuntimeConfigError(
+      "PINNING_UNAVAILABLE",
+      "SSL pinning is unavailable on this app build/runtime."
+    );
+  }
+
+  try {
+    await pinning.initializeSslPinning({
+      [hostname]: {
+        includeSubdomains: config.pinningIncludeSubdomains,
+        publicKeyHashes: config.pinnedPublicKeyHashes,
+        expirationDate: config.pinningExpirationDate,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SignerRuntimeConfigError(
+      "PINNING_INIT_FAILED",
+      `Failed to initialize SSL pinning: ${message}`
+    );
+  }
+
+  lastInitializedConfigFingerprint = fingerprint;
+}
+
+export function resetSignerCertificatePinningForTests(): void {
+  lastInitializedConfigFingerprint = null;
+}
+
+export function setPinningModuleLoaderForTests(loader: (() => Promise<PinningModule>) | null): void {
+  pinningModuleLoader = loader;
+}

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -34,6 +34,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-ssl-public-key-pinning": "^1.2.6",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
         "starknet": "^9.2.1"
@@ -12127,6 +12128,19 @@
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-ssl-public-key-pinning": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-native-ssl-public-key-pinning/-/react-native-ssl-public-key-pinning-1.2.6.tgz",
+      "integrity": "sha512-WrWCRgXSet/lw8VVgrnTM5RXI+YWmSxE4+PmWcxFOUq7Kea+arkYASvDD1Dajw6yFGEw4GYuvIRdp6s7KxO60Q==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -42,6 +42,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-ssl-public-key-pinning": "^1.2.6",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
     "starknet": "^9.2.1"


### PR DESCRIPTION
## Summary
Implements issue #67 with fail-closed certificate pinning on Starkclaw remote signer path.

## What changed
- Added `apps/mobile/lib/signer/pinning.ts`:
  - Initializes SSL public-key pinning for signer host before remote signing.
  - Caches initialized config to avoid repeated init calls.
  - Fails closed with deterministic runtime errors (`PINNING_UNAVAILABLE`, `PINNING_INIT_FAILED`).
- Hardened `apps/mobile/lib/signer/runtime-config.ts`:
  - Added production requirements for pinning config:
    - `EXPO_PUBLIC_SISNA_PINNED_PUBKEYS` required in production.
    - At least two pins required in production.
    - Base64 sha256(SPKI) format validation.
  - Added optional config:
    - `EXPO_PUBLIC_SISNA_PIN_INCLUDE_SUBDOMAINS`
    - `EXPO_PUBLIC_SISNA_PIN_EXPIRATION_DATE` (yyyy-MM-dd)
- Wired pinning into transfer execution (`apps/mobile/lib/agent/transfer.ts`) before creating `KeyringProxySigner`.
- Added TDD coverage:
  - `apps/mobile/lib/signer/__tests__/pinning.test.ts`
  - Expanded `apps/mobile/lib/signer/__tests__/runtime-config.test.ts`
  - Expanded `apps/mobile/lib/agent/__tests__/transfer.retry.test.ts`
- Added dependency:
  - `react-native-ssl-public-key-pinning`

## Threat model notes
- Mitigates MITM via compromised CA in remote signer transport path by pinning signer TLS public key hashes.
- Keeps fail-closed posture: remote signing aborts before key use if pinning cannot initialize.
- Complements existing mTLS + HMAC controls, does not replace them.

## Rollback plan
- Revert this PR to restore previous behavior.
- In emergency, switch app to local signer mode (`EXPO_PUBLIC_SIGNER_MODE=local`) while rollback propagates.

## Validation
- `npm ci --prefix apps/mobile`
- `npm test --prefix apps/mobile -- --run`
- `npm run typecheck --prefix apps/mobile`
- `npm run lint --prefix apps/mobile`

Closes #67
