### PR TITLE
chore(#73): retire legacy AgentAccount production path defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,8 @@ Assume the user does not see raw command output; summarize important results.
 | Check all | `./scripts/check` | runs mobile lint/typecheck + contracts tests |
 | App dev | `./scripts/app/dev` | `expo start` |
 | Contracts test | `./scripts/contracts/test` | scarb + snforge |
-| Declare AgentAccount (one-time, Sepolia) | `STARKNET_DEPLOYER_ADDRESS=... STARKNET_DEPLOYER_PRIVATE_KEY=... ./scripts/contracts/declare-agent-account` | required before any in-app account deploy |
+| Declare session-account lineage (one-time, Sepolia) | `STARKNET_DEPLOYER_ADDRESS=... STARKNET_DEPLOYER_PRIVATE_KEY=... ./scripts/contracts/declare-session-account` | canonical production path |
+| Declare legacy AgentAccount (migration/debug only) | `ALLOW_LEGACY_AGENT_ACCOUNT=1 STARKNET_DEPLOYER_ADDRESS=... STARKNET_DEPLOYER_PRIVATE_KEY=... ./scripts/contracts/declare-agent-account` | non-production fallback |
 </current>
 </commands>
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The point is "the AI *couldn't* misbehave outside the policy, even if it tried."
 
 ## How It Works (No Hand-Waving)
 
-Starkclaw uses a custom Starknet account contract (`contracts/agent-account`) with a split key model:
+Starkclaw uses Starknet session-account lineage (canonical source: `keep-starknet-strange/starknet-agentic/contracts/session-account`) with a split key model:
 
 - **Owner key (master)**:
   - Deploys the account.
@@ -145,10 +145,10 @@ Notes:
 - `EXPECTED_SESSION_ACCOUNT_CLASS_HASH` is optional but pinned by default; declare fails on mismatch
 - Existing wallets without persisted class-hash metadata remain on legacy hash addressing (no silent remap)
 
-Legacy fallback (migration/debug only):
+Legacy fallback (migration/debug only, explicitly gated):
 
 ```bash
-./scripts/contracts/declare-agent-account
+ALLOW_LEGACY_AGENT_ACCOUNT=1 ./scripts/contracts/declare-agent-account
 ```
 
 ### In The App (Planned)
@@ -167,7 +167,7 @@ See `STATUS.md` for current progress.
 ## Repo Layout
 
 - `apps/mobile/`: Expo app (Expo Router)
-- `contracts/agent-account/`: legacy Cairo account package retained during migration
+- `contracts/`: Starknet account-contract tooling/docs
 - `scripts/`: deterministic commands (CI calls these)
 - `spec.md`: product spec
 - `IMPLEMENTATION_PLAN.md`: milestone plan
@@ -216,7 +216,7 @@ If you find a vulnerability, please report it responsibly. See [SECURITY.md](./S
 
 ## Acknowledgements
 
-- The AA safety-rails baseline is derived from `keep-starknet-strange/starknet-agentic` (vendored into `contracts/agent-account`).
+- Canonical AA safety-rails lineage is `keep-starknet-strange/starknet-agentic/contracts/session-account`.
 - Starknet.js for transaction building and signing.
 
 ## License

--- a/apps/mobile/scripts/declare-agent-account.mjs
+++ b/apps/mobile/scripts/declare-agent-account.mjs
@@ -13,6 +13,13 @@ function requiredEnv(name) {
   return v;
 }
 
+if (process.env.ALLOW_LEGACY_AGENT_ACCOUNT !== "1") {
+  throw new Error(
+    "Legacy AgentAccount declare path is disabled by default. " +
+      "Use declare-session-account, or set ALLOW_LEGACY_AGENT_ACCOUNT=1 for migration/debug only."
+  );
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../../..");
@@ -75,4 +82,3 @@ main().catch((err) => {
   console.error(err instanceof Error ? err.message : String(err));
   process.exit(1);
 });
-

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,17 +6,16 @@ If the app UI and the agent logic are compromised, the contracts are still the f
 
 ## Packages
 
-- `agent-account/`: legacy local contract package retained during migration
-  - canonical production lineage is `session-account` from `starknet-agentic`
+- Canonical production lineage: `session-account` from `starknet-agentic`
 
 ## What The Account Enforces (MVP)
 
-The `AgentAccount` contract supports two signer modes:
+The canonical session-account path supports two signer modes:
 
 - **Owner signature**: unrestricted account execution
 - **Session key signature**: restricted execution (policy enforced in `__execute__`)
 
-Session key policy fields (see `agent-account/src/interfaces.cairo`):
+Session key policy fields (see upstream session-account interfaces):
 
 - `valid_after`, `valid_until`
 - `spending_token`, `spending_limit` (24h rolling window)
@@ -33,7 +32,7 @@ From repo root:
 ./scripts/contracts/test
 ```
 
-Or inside the package:
+Legacy package tests (migration/debug only):
 
 ```bash
 cd agent-account
@@ -67,10 +66,10 @@ EXPECTED_SESSION_ACCOUNT_CLASS_HASH=0x... \
 ./scripts/contracts/declare-session-account
 ```
 
-Legacy fallback (migration/debug only):
+Legacy fallback (migration/debug only, explicitly gated):
 
 ```bash
-./scripts/contracts/declare-agent-account
+ALLOW_LEGACY_AGENT_ACCOUNT=1 ./scripts/contracts/declare-agent-account
 ```
 
 If you change canonical session-account code:

--- a/docs/security/ISSUE53_MIGRATION_PREFLIGHT.md
+++ b/docs/security/ISSUE53_MIGRATION_PREFLIGHT.md
@@ -9,6 +9,13 @@ Execute the contract lineage migration with minimum security regression risk:
 - move mobile contract calls to `session-account` API shape,
 - preserve remote signer (`SISNA`) execution path behavior.
 
+## Canonical Path + Legacy Fallback Policy
+- Canonical production declare path: `./scripts/contracts/declare-session-account`
+- Legacy fallback path: `./scripts/contracts/declare-agent-account`
+  - explicitly gated and disabled by default
+  - requires `ALLOW_LEGACY_AGENT_ACCOUNT=1`
+  - intended only for migration/debug compatibility
+
 ## Current Drift Snapshot
 
 ### Legacy contract lineage still active

--- a/scripts/contracts/declare-agent-account
+++ b/scripts/contracts/declare-agent-account
@@ -6,5 +6,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # Legacy path (AgentAccount). Keep only for migration/debug fallback.
 # Canonical production path is: ./scripts/contracts/declare-session-account
 
+if [[ "${ALLOW_LEGACY_AGENT_ACCOUNT:-}" != "1" ]]; then
+  echo "Blocked: legacy AgentAccount declare path is disabled by default."
+  echo "Use canonical path: ./scripts/contracts/declare-session-account"
+  echo "To override for migration/debug only, re-run with:"
+  echo "  ALLOW_LEGACY_AGENT_ACCOUNT=1 ./scripts/contracts/declare-agent-account"
+  exit 1
+fi
+
 # Uses starknet.js from apps/mobile to avoid duplicating dependencies at repo root.
 node "$ROOT_DIR/apps/mobile/scripts/declare-agent-account.mjs"


### PR DESCRIPTION
## Summary
Closes remaining production-path ambiguity for legacy AgentAccount tooling/docs.

## Changes
- Gate legacy declare script behind explicit env flag:
  - `scripts/contracts/declare-agent-account`
  - `apps/mobile/scripts/declare-agent-account.mjs`
  - requires `ALLOW_LEGACY_AGENT_ACCOUNT=1`
- Keep canonical production declare path as:
  - `./scripts/contracts/declare-session-account`
- Update docs and maintainer guidance to remove legacy-default messaging:
  - `README.md`
  - `contracts/README.md`
  - `CLAUDE.md`
  - `docs/security/ISSUE53_MIGRATION_PREFLIGHT.md`

## Security impact
- Prevents accidental use of legacy production path.
- Makes legacy path an explicit, operator-acknowledged fallback for migration/debug only.

## Backward compatibility
- No runtime/mobile execution behavior change.
- Legacy declare still available when explicitly opted-in.

## Rollback
- Revert this PR to restore previous legacy script behavior.

## Validation
- `bash -n scripts/contracts/declare-agent-account`
- `node --check apps/mobile/scripts/declare-agent-account.mjs`
- Link/reference consistency check across docs/scripts (`declare-session-account` + `ALLOW_LEGACY_AGENT_ACCOUNT`).

Closes #73
