### PR TITLE
chore(#53): clean residual AgentAccount default wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Assume the user does not see raw command output; summarize important results.
   - `lib/wallet/`, `lib/policy/`, `lib/agent/`, `lib/activity/`: Live execution libs (exists, not wired)
   - `app/(tabs)/`: Tab screens (index, trade, agent, policies, inbox)
   - `app/(onboarding)/`: Onboarding flow
-- `contracts/agent-account/`: Cairo account contract + tests (session keys + policy enforcement)
+- `contracts/`: Starknet account-contract tooling/docs (canonical lineage: `session-account` from `starknet-agentic`)
 - `scripts/`: Canonical commands used by CI (`check`, `app/dev`, `contracts/test`, etc.)
 - `.github/workflows/ci.yml`: CI entrypoint (runs `./scripts/check`)
 - `spec.md`: Expanded MVP spec

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,7 +13,7 @@ M09 (Subset): Audit Export + Hardening
 - Expanded spec written in `spec.md`.
 - Implementation plan and milestones written in `IMPLEMENTATION_PLAN.md`.
 - M00 bootstrap: Expo app scaffold + Cairo contracts workspace + deterministic scripts + CI.
-- M01 baseline safety rails: vendored `contracts/agent-account` and wired into `scripts/contracts/test`.
+- M01 baseline safety rails: session-account lineage integration and deterministic contract checks wired into `scripts/contracts/test`.
 - M02 wallet libs: deterministic account address + RPC client with retry/fallback (exists in `apps/mobile/lib/starknet/`, not wired to UI).
 - M03 deploy libs: funding UX + deploy account transaction flow (exists in `apps/mobile/lib/wallet/`, not wired to UI).
 - M04 policy libs: create/register/revoke session keys (exists in `apps/mobile/lib/policy/`, not wired to UI).
@@ -49,11 +49,11 @@ M09 (Subset): Audit Export + Hardening
 
 ### Live Mode (When Wired, See [#2](https://github.com/keep-starknet-strange/starkclaw/issues/2))
 
-**One-time setup:** Declare `AgentAccount` class on Sepolia:
+**One-time setup:** Declare canonical session-account class on Sepolia:
 ```bash
 STARKNET_DEPLOYER_ADDRESS=0x... \
 STARKNET_DEPLOYER_PRIVATE_KEY=0x... \
-./scripts/contracts/declare-agent-account
+./scripts/contracts/declare-session-account
 ```
 
 **Manual smoke test:**

--- a/apps/mobile/lib/onboarding/onboarding-flow.ts
+++ b/apps/mobile/lib/onboarding/onboarding-flow.ts
@@ -17,7 +17,7 @@ export type OnboardingStep =
   | "network"       // Choose sepolia (default) or mainnet (opt-in, warned)
   | "create_wallet" // Generate keypair + compute address
   | "fund"          // Deposit ETH/STRK to the computed address
-  | "deploy"        // Deploy AgentAccount on-chain
+  | "deploy"        // Deploy SessionAccount on-chain
   | "session_key"   // Create + register first session key
   | "first_action"  // Execute a constrained test action
   | "complete";     // Onboarding done


### PR DESCRIPTION
## Summary
Final cleanup for #53 to remove residual `AgentAccount` default wording in maintainer/runtime docs and onboarding comments.

## Changes
- `STATUS.md`
  - switched one-time declare command from legacy `declare-agent-account` to canonical `declare-session-account`.
  - updated M01 wording to session-account lineage.
- `CLAUDE.md`
  - updated repo structure guidance to canonical session-account lineage wording.
- `apps/mobile/lib/onboarding/onboarding-flow.ts`
  - changed deploy-step inline comment from `Deploy AgentAccount` to `Deploy SessionAccount`.

## Why
All execution/config paths are now session-account canonical; these stale strings caused ambiguity in maintainer guidance.

## Threat model / risk
- No runtime behavior change.
- Reduces operator error risk by avoiding legacy-default interpretation.

## Rollback
Revert this PR to restore prior wording only.

## Validation
- `npm run lint --prefix apps/mobile`
- `npm run typecheck --prefix apps/mobile`

Refs #53
