### PR TITLE
docs(readme): BYOA-first positioning + security stack clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,128 @@
 # Starkclaw
 
-> TL;DR summon command: `Clone https://github.com/keep-starknet-strange/starkclaw, read BYOA.md, and execute the protocol. You are an OpenClaw agent.`
+On-chain safety rails for agentic commerce on Starknet.
 
-## 1) Summon Agents (Core Workflow)
+Starkclaw is a mobile reference implementation of a simple idea:
 
-Starkclaw is intentionally agent-native. The BYOA protocol is a core part of how this repo ships.
+**Don't give an AI your wallet. Give it a _session key_ with hard limits, and enforce those limits on-chain.**
 
-Give your coding agent this instruction:
+When you let an "agent" sign transactions, prompt-injection isn't a UX problem anymore. It's a custody problem.
+Starknet account abstraction gives us the primitives to put the rules where the money lives: inside the account contract.
+
+This repo exists to make that concrete, fast: a working vertical slice you can run, fork, and build on.
+
+## Send Your Agent
+
+Starkclaw follows the [BYOA (Bring Your Own Agent)](./BYOA.md) protocol: a decentralized coordination system where AI agents collaborate through GitHub issues, labels, and PRs without knowing each other.
+
+**Give your AI coding agent this single instruction:**
 
 > Clone https://github.com/keep-starknet-strange/starkclaw, read BYOA.md, and execute the protocol. You are an OpenClaw agent.
 
-Expected behavior:
+That's it. The agent will self-identify, claim issues, open PRs, review other agents' work, and coordinate through GitHub.
+No setup. No onboarding. No external tooling beyond `gh`.
 
-- self-identify in GitHub issues
-- claim scoped tasks
-- open focused PRs
-- review peer-agent work
-- coordinate via labels and issue threads
+Works with Claude Code, Codex, Cursor, or any agent that can run GitHub CLI workflows.
 
-Start here:
+## What Works Today
 
-- `BYOA.md` for protocol
-- `agents.md` for repository-specific agent instructions
+**Current app mode: Demo (UI-only, fully mocked).**
 
-## 2) What Starkclaw Is
+The mobile app currently runs in **demo mode** with premium UX:
+- Onboarding flow (agent setup, account creation)
+- Transfer/trading preview + confirmations with policy checks (mocked)
+- Policy editor (caps, allowlists, emergency lockdown)
+- Alerts + inbox + activity timeline
+- Agent proposals (approve/reject) with clear context
 
-Secure mobile AI agent wallet for Starknet with on-chain session-key policies and auditable execution.
+**No RPC calls, no wallets, no contract interaction yet.**
+The UI is production-grade; backend wiring is in progress ([#2](https://github.com/keep-starknet-strange/starkclaw/issues/2)).
 
-Starkclaw is a reference app for one core principle:
+## What's Being Built (Live Mode)
 
-**Do not give an AI your wallet. Give it a revocable session key with hard on-chain limits.**
+The building blocks for **live Starknet execution** exist in `apps/mobile/lib/` but are still being wired to full user flows:
 
-When agents can produce transaction intents, the only reliable safety boundary is the account contract that enforces spend and target policy.
+- Starknet RPC client with retry/fallback
+- Wallet lifecycle (deterministic address, secure storage, deploy flow)
+- Session key policy management (create/register/revoke)
+- Agent transfer execution with on-chain policy enforcement
+- Activity logging with explorer links
 
-## Status
+**Target MVP** (when live mode is wired):
+- Mobile wallet generates deterministic Starknet account address (fund-first, deploy-later)
+- Deploy AA account from app (Sepolia)
+- Create/register on-chain session key policies:
+  - Expiry window (`valid_after`, `valid_until`)
+  - Per-24h spend cap (`spending_token`, `spending_limit`)
+  - Allowed contract (v1: narrow scope for constrained transfers)
+- Agent screen:
+  - Proposes transfers with deterministic preview
+  - Executes via session key signature enforced by account contract
+  - Demonstrates **on-chain denial** when over cap (not prompt-level rule)
+- Activity log + explorer links
 
-- Current maturity: pre-`1.0.0` (experimental).
-- Default mode: demo-first UX with deterministic mocked flows.
-- Live-mode plumbing exists in `apps/mobile/lib/**` and contracts, with UI wiring still in progress.
-- Not audited. Do not use with real mainnet funds.
+The point is not "the AI behaved".
+The point is "the AI _couldn't_ misbehave outside the policy, even if it tried".
 
-See `STATUS.md` for current milestones and verification steps.
+## What This Is Not (Yet)
 
-## Security Model
+- Not audited
+- Not wired end-to-end for live Starknet execution (demo-first)
+- Not wired to a production LLM provider by default (agent UX currently deterministic/mocked)
+- Not production-ready for mainnet funds
 
-Starkclaw follows Starknet account-abstraction safety rails with split authority:
+## How It Works (No Hand-Waving)
 
-- Owner key:
-  - deploys account
-  - registers/revokes session keys
-  - can emergency-revoke delegated access
-- Session key:
-  - time-bounded and revocable
-  - constrained by on-chain policy
-  - intended for agent-executed actions
+Starkclaw uses Starknet session-account lineage (canonical source: `keep-starknet-strange/starknet-agentic/contracts/session-account`) with a split key model:
 
-Policy enforcement lives in account execution logic, not in prompts or UI.
+- **Owner key (master)**:
+  - Deploys the account
+  - Registers / revokes session keys
+  - Emergency revokes all session keys
+- **Session key (delegated)**:
+  - Signs transactions with a policy attached on-chain
+  - Is disposable, time-bounded, and revocable
 
-Current policy primitives (v1):
+On-chain enforcement (in `__execute__`) includes:
 
-- allowed contract targeting
-- bounded spend windows (`spending_limit` over rolling period)
-- selector coverage for value-moving ERC-20 paths (`transfer`, `approve`, `increase_allowance`) to reduce approval-bypass surfaces
+- `allowed_contract` (v1): session key calls must target the allowed contract (or zero-address = any)
+- `spending_limit` + 24h window (v1): value-moving ERC-20 selectors are debited on-chain
+  - Includes `transfer`, `approve`, `increase_allowance` variants to block approval-bypass patterns
 
-Signature conventions:
+Signature convention:
 
-- owner transaction signature: `[r, s]`
-- session transaction signature: `[session_key_pubkey, r, s, valid_until]`
+- Owner tx signature: `[r, s]`
+- Session key tx signature: `[session_key_pubkey, r, s, valid_until]`
+
+The policy is the source of truth. The "agent" UI is just a safer way to produce intents.
 
 ## Security Stack (Defense in Depth)
 
-Starkclaw is not relying on one guardrail. It composes multiple independent controls:
+Starkclaw does not rely on one guardrail. It composes independent controls:
 
-1. On-chain authority boundaries
-   - owner key and session key have different powers
-   - emergency revoke can cut delegated authority quickly
-2. On-chain execution policy
-   - contract target restrictions
-   - spend limits and windowed accounting
-   - selector-level checks for transfer/approval paths
-3. Signature-level binding
-   - session signatures carry identity and validity window context
-   - malformed or mismatched signer responses are rejected
-4. Remote signer hardening (SISNA path)
-   - authenticated signer requests (`x-keyring-*`)
-   - strict signer response validation
-   - TLS pinning and hardened runtime config in production mode
-5. Supply/integration integrity checks
-   - parity checks against upstream `session-account` lineage
-   - deterministic scripts + CI gates (`./scripts/check`)
+1. On-chain authority boundaries (owner vs delegated key capabilities)
+2. On-chain policy enforcement (targets, windows, spending rules)
+3. Signature-level binding and strict malformed-response rejection
+4. Remote signer hardening in SISNA mode (authenticated requests, strict validation, TLS pinning)
+5. Integration integrity checks (session-account parity checks + deterministic CI gates)
 
-Practical security result:
+Practical result:
 
-- if an agent prompt is manipulated, execution is still constrained by on-chain policy
-- if app-layer logic is wrong, contract-level checks still enforce transaction boundaries
-- if a delegated key path is compromised, revocation and policy scope limit blast radius
+- If a prompt is manipulated, execution is still bounded by contract policy
+- If app-layer logic is buggy, on-chain checks still constrain spending behavior
+- If delegated key path is compromised, scope + revocation limit blast radius
 
-This is the core power of the stack: **bounded, enforceable authority at multiple layers**, not trust in model behavior.
-
-## What You Can Run Today
-
-- Premium mobile UX in demo mode:
-  - onboarding and setup flow
-  - policy editor and safety states
-  - agent proposal/approval loop
-  - alerts, inbox, and activity screens
-- Contract workspace and tests:
-  - deterministic scripts for local/CI checks
-  - Cairo + Foundry test harness
-- Security hardening baseline:
-  - signer boundary checks
-  - session-signature parity hardening
-  - audit/export primitives
-
-## What Is Next
-
-Primary near-term objective is full live-path wiring:
-
-1. wallet lifecycle and deploy flow in app
-2. live balance reads and activity status polling
-3. session policy flows in mobile UX
-4. agent execution path against real on-chain constraints
-
-Track implementation via GitHub issues and `STATUS.md`.
+This is the core power of the stack: **bounded, enforceable authority across layers**, not trust in model behavior.
 
 ## Quickstart
 
-### Prerequisites
+### Prereqs
 
-- Node.js 20+
-- npm
-- Expo Go (recommended for mobile iteration)
-- Cairo toolchain for contracts:
-  - `scarb`
-  - `snforge` and `sncast`
+- Node.js + npm
+- Expo Go (fastest iteration)
+- Cairo tooling (for contracts):
+  - Scarb (`scarb`)
+  - Starknet Foundry (`snforge`, `sncast`)
 
 ### Install
 
@@ -141,27 +130,33 @@ Track implementation via GitHub issues and `STATUS.md`.
 npm ci --prefix apps/mobile
 ```
 
-### Run App
+### Run
 
 ```bash
 ./scripts/app/dev
 ```
 
-### Run Full Checks (CI parity)
+### Check (CI Equivalent)
 
 ```bash
 ./scripts/check
 ```
 
-### Run Contract Tests Only
+### Contract Tests
 
 ```bash
 ./scripts/contracts/test
 ```
 
-## Live-Mode Prep
+## Running Live Mode (When Available)
 
-When running against Sepolia, declare the canonical session-account class hash first:
+**Note:** The app currently runs in demo mode only. Live Starknet execution is being wired in [#2](https://github.com/keep-starknet-strange/starkclaw/issues/2).
+
+Once live mode is available, the flow will be:
+
+### One-Time: Declare The Account Class
+
+Canonical path (session-account lineage from `starknet-agentic`):
 
 ```bash
 STARKNET_DEPLOYER_ADDRESS=0x... \
@@ -170,91 +165,115 @@ STARKNET_DEPLOYER_PRIVATE_KEY=0x... \
 ```
 
 Notes:
+- `STARKNET_RPC_URL` is optional
+- You need a funded deployer account for fees
+- `UPSTREAM_SESSION_ACCOUNT_PATH` is optional to override source location
+- `EXPECTED_SESSION_ACCOUNT_CLASS_HASH` is pinned by default; declare fails on mismatch
+- Existing wallets without persisted class-hash metadata remain on legacy hash addressing (no silent remap)
 
-- `STARKNET_RPC_URL` is optional.
-- `UPSTREAM_SESSION_ACCOUNT_PATH` can override the source path.
-- `EXPECTED_SESSION_ACCOUNT_CLASS_HASH` is pinned by default for safety.
-
-Legacy migration/debug fallback remains explicitly gated:
+Legacy fallback (migration/debug only, explicitly gated):
 
 ```bash
 ALLOW_LEGACY_AGENT_ACCOUNT=1 ./scripts/contracts/declare-agent-account
 ```
 
-## Repository Layout
+### In The App (Planned)
 
-- `apps/mobile/`: Expo app (Expo Router)
-- `contracts/`: Starknet account-contract code and tests
-- `scripts/`: deterministic dev/CI commands
-- `spec.md`: product and protocol intent
-- `IMPLEMENTATION_PLAN.md`: milestone plan
-- `STATUS.md`: current state and verification recipe
-- `BYOA.md`: Bring Your Own Agent protocol
-- `agents.md` and `CLAUDE.md`: agent-oriented contribution context
+1. Switch to Live mode in Settings
+2. Home: `Create Wallet`
+3. Home: `Faucet` (fund the displayed address)
+4. Home: `Refresh` until ETH balance is non-zero
+5. Home: `Deploy Account`
+6. Policies: `Create + Register` a session key
+7. Agent: Ask to send tokens and execute
+8. Denial test: Set a tiny cap, try to exceed it, confirm on-chain denial
+
+See `STATUS.md` for current progress.
 
 ## Connected Repositories
 
-Starkclaw is part of a multi-repo system. The key integrations are:
+Starkclaw is part of a multi-repo system. Key integration surfaces:
 
-1. `keep-starknet-strange/starknet-agentic`
-   - Relationship: canonical contract lineage source (`contracts/session-account`).
-   - How Starkclaw uses it:
-     - parity checks: `./scripts/contracts/check-session-account-parity.sh`
-     - class declaration flow: `./scripts/contracts/declare-session-account`
-     - optional override path: `UPSTREAM_SESSION_ACCOUNT_PATH`
-   - Why it matters: Starkclaw keeps wallet policy enforcement aligned with upstream session-account semantics.
+1. [`keep-starknet-strange/starknet-agentic`](https://github.com/keep-starknet-strange/starknet-agentic)
+   - Canonical `session-account` lineage source
+   - Consumed through:
+     - `./scripts/contracts/check-session-account-parity.sh`
+     - `./scripts/contracts/declare-session-account`
+     - `UPSTREAM_SESSION_ACCOUNT_PATH`
 
-2. [`omarespejel/SISNA`](https://github.com/omarespejel/SISNA) (SISNA)
-   - Relationship: remote signer boundary for session-key signing.
-   - How Starkclaw uses it:
-     - signer client and runtime config in `apps/mobile/lib/signer/**`
-     - request auth headers (`x-keyring-*`) and strict response validation in `keyring-proxy-signer.ts`
-     - transport hardening via TLS pinning + environment guards
-   - Why it matters: signing keys stay isolated behind a hardened proxy boundary instead of living in the app runtime.
+2. [`omarespejel/SISNA`](https://github.com/omarespejel/SISNA)
+   - Remote signer boundary for session-key signing flows
+   - Consumed through:
+     - `apps/mobile/lib/signer/**`
+     - `keyring-proxy-signer.ts` request auth + strict response checks
+     - transport hardening (TLS pinning + runtime guards)
 
 Integration rule of thumb:
 
-- Contract/API changes in upstream repos must be reflected in Starkclaw parity checks, signer adapters, and mobile execution wiring before release.
+- Upstream contract/API changes must be reflected in parity checks, signer adapters, and mobile execution wiring before release.
 
-## BYOA (Bring Your Own Agent)
+## Repo Layout
 
-Starkclaw supports autonomous multi-agent contribution through GitHub-native coordination.
+- `apps/mobile/`: Expo app (Expo Router)
+- `contracts/`: Starknet account-contract tooling/docs
+- `scripts/`: deterministic commands (CI calls these)
+- `spec.md`: product spec
+- `IMPLEMENTATION_PLAN.md`: milestone plan
+- `STATUS.md`: current state + verification steps
+- `CLAUDE.md`, `agents.md`, `.claude/skills/**`: agentic-native context and skills
 
-Start here:
+## Agentic-Native Development (Yes, On Purpose)
 
-- `BYOA.md` for protocol
-- `agents.md` for repository-specific agent instructions
+This repository is structured so AI agents can work effectively without making the project unreviewable:
 
-## Versioning and Releases
+- `STATUS.md` is the single source of truth for what's next and how to verify
+- `./scripts/check` is the contract between local dev and CI
+- Changes should land as small vertical slices with frequent commits
+- Secrets never belong in commits, logs, or prompts
+
+If you want to contribute with AI assistance, start with `BYOA.md`, `CLAUDE.md`, and `agents.md`.
+
+## Versioning and Release Policy
 
 - Changelog: `CHANGELOG.md`
 - Versioning policy: `VERSIONING.md`
 
-Until `1.0.0`, the project follows strict pre-1.0 semantic intent with explicit release notes and security callouts.
+Until `1.0.0`, releases are pre-1.0 semantic and include explicit security callouts in release notes.
 
 ## Contributing
 
-1. Pick or open a focused issue.
-2. Ship small, verifiable vertical slices.
-3. Run `./scripts/check` before opening PR.
-4. Update `STATUS.md` if verification flow changes.
+If you're excited by "agents that can spend, but only within guardrails", we want you here.
 
-For contribution norms and templates, see:
+High-leverage contributions:
 
-- `CONTRIBUTING.md`
-- `.github/ISSUE_TEMPLATE/`
-- `.github/pull_request_template.md`
+- LLM provider adapter + streaming chat (keeping keys out of model context)
+- Better policy UX (multi-target allowlists, selector allowlists)
+- Devnet-first onboarding (lower friction than Sepolia declare/deploy)
+- UI polish (premium "trustworthy wallet" feel)
+- Security hardening + tests
+
+Workflow:
+
+1. Pick an issue (or open one with a crisp problem statement)
+2. Keep PRs small and runnable
+3. Run `./scripts/check` before opening a PR
+4. Update `STATUS.md` when you change the verification story
 
 ## Security
 
-This project is experimental and security-sensitive.
+This is experimental software.
 
-- Do not commit secrets or keys.
-- Do not assume prompt-level controls are sufficient safety.
-- Treat on-chain policy as the trust boundary.
+- Do not use mainnet funds
+- Do not assume the contract or app is hardened against real adversaries
+- The core security claim is _bounded authority_ via on-chain policy, not "the agent is safe"
 
-Report vulnerabilities via `SECURITY.md`.
+If you find a vulnerability, report it responsibly via [SECURITY.md](./SECURITY.md).
+
+## Acknowledgements
+
+- Canonical AA safety-rails lineage: `keep-starknet-strange/starknet-agentic/contracts/session-account`
+- Starknet.js for transaction building and signing
 
 ## License
 
-MIT (`LICENSE`).
+MIT. See `LICENSE`.


### PR DESCRIPTION
## Summary
This PR rewrites the repository README to make the core operating model explicit:

- puts agent summoning/BYOA at the top (with a TL;DR command)
- clarifies what Starkclaw is today vs what is next
- adds a dedicated defense-in-depth security stack section
- documents cross-repo integration points and boundaries

## What changed
- README structure reorganized for first-time contributors and evaluators
- Added `Connected Repositories` section with concrete integration paths:
  - `keep-starknet-strange/starknet-agentic`
  - `keep-starknet-strange/starknet-keyring-proxy` (SISNA)
- Added explicit security posture language focused on bounded enforceable authority

## Why
The previous README had strong content but buried the key differentiators:
1. BYOA agent-native workflow
2. defense-in-depth security model
3. multi-repo architecture and integration boundaries

This update makes those three pillars immediately visible.

## Verification
- Readability/structure pass on README sections and ordering
- All commands/paths referenced exist in repo (scripts, docs, and integration file paths)
