### PR TITLE
chore(ci): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/apps/mobile"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/contracts/agent-account/scripts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` for `starkclaw`
- enable weekly dependency update PRs for:
  - `apps/mobile` npm deps
  - `contracts/agent-account/scripts` npm deps
  - GitHub Actions
- label update PRs with `dependencies`

## Why
- keeps dependency review and security pipeline fed with fresh updates
- closes the missing Dependabot item from tri-repo readiness
