### PR TITLE
docs(sisna): align Starkclaw with production key-custody guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Starkclaw is part of a multi-repo system. Key integration surfaces:
      - `apps/mobile/lib/signer/**`
      - `keyring-proxy-signer.ts` request auth + strict response checks
      - transport hardening (TLS pinning + runtime guards)
+   - Production key-custody note:
+     - SISNA currently requires explicit
+       `KEYRING_ALLOW_INSECURE_IN_PROCESS_KEYS_IN_PRODUCTION=true`
+       when running with in-process keys in production.
+     - This is a temporary explicit-risk guard until external KMS/HSM
+       signer backend mode is available.
 
 Integration rule of thumb:
 

--- a/apps/mobile/lib/signer/README.md
+++ b/apps/mobile/lib/signer/README.md
@@ -80,6 +80,14 @@ Certificate pinning behavior:
 - If pinning cannot initialize in remote mode, execution fails closed.
 - Expo Go does not provide the required native module. Use a dev/prod build for remote signer testing.
 
+Server-side production guard (SISNA):
+
+- SISNA now fails production startup unless
+  `KEYRING_ALLOW_INSECURE_IN_PROCESS_KEYS_IN_PRODUCTION=true` is explicitly set
+  while in-process key custody is still in use.
+- This is an explicit temporary-risk acknowledgement until SISNA external KMS/HSM
+  signing mode is enabled.
+
 ## Error Codes
 
 ### `KeyringProxySignerError`


### PR DESCRIPTION
## Summary
Align Starkclaw docs with latest SISNA production key-custody guard.

## Changes
- `README.md`
  - added integration note under SISNA section for explicit production guard:
    `KEYRING_ALLOW_INSECURE_IN_PROCESS_KEYS_IN_PRODUCTION=true`
  - clarified that this is temporary until external KMS/HSM signer mode is available
- `apps/mobile/lib/signer/README.md`
  - added server-side production guard note in Security Guarantees section

## Why
This keeps cross-repo security messaging consistent and avoids deployment confusion when Starkclaw teams wire remote signer mode against latest SISNA.
