### PR TITLE
ci(security): fix workflow permissions CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -36,4 +39,3 @@ jobs:
 
       - name: Run checks
         run: ./scripts/check
-

--- a/.github/workflows/session-parity-audit.yml
+++ b/.github/workflows/session-parity-audit.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   session-parity:
     runs-on: ubuntu-latest

--- a/.github/workflows/signer-client.yml
+++ b/.github/workflows/signer-client.yml
@@ -18,11 +18,17 @@ on:
       - 'scripts/test/signer-client.sh'
       - '.github/workflows/signer-client.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Signer Client Tests
     runs-on: ubuntu-latest
     timeout-minutes: 5 # Fast path - should complete quickly
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -57,6 +63,8 @@ jobs:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Resolve open CodeQL workflow-permissions findings by declaring explicit least-privilege permissions in workflows flagged by alerts.

## Changes
- `.github/workflows/ci.yml`
  - added top-level `permissions: contents: read`
- `.github/workflows/session-parity-audit.yml`
  - added top-level `permissions: contents: read`
- `.github/workflows/signer-client.yml`
  - added top-level `permissions: contents: read`
  - added job-level permissions:
    - `test`: `contents: read`, `id-token: write` (for Codecov OIDC path)
    - `lint`: `contents: read`

## Security impact
- Aligns workflows with least-privilege token usage.
- Directly addresses CodeQL `actions/missing-workflow-permissions` alerts.
